### PR TITLE
Fix Yara 3.4 template rendering and init

### DIFF
--- a/app/templates/analysis/yara_analysis_v3_4.html
+++ b/app/templates/analysis/yara_analysis_v3_4.html
@@ -1,4 +1,5 @@
-{% for yara_result in analysis.details %}
+{% if analysis_presenter and analysis_presenter.details and 'scan_results' in analysis_presenter.details %}
+{% for yara_result in analysis_presenter.details['scan_results'] %}
 <div class="panel panel-default">
     <div class="panel-heading">
         <h3 class="panel-title">{{yara_result['rule']}}</h3>
@@ -30,36 +31,37 @@
             <div class="panel panel-default">
                 <div class="panel-heading" role="tab" id="heading_{{yara_result['rule']}}">
                     <h4 class="panel-title">
-                        <a role="button" data-toggle="collapse" data-parent="#{{yara_result['rule']}}" href="#collapse_{{yara_result['rule']}}" aria-expanded="true" aria-controls="collapse_{{yara_result['rule']}}">
+                        <a role="button" data-bs-toggle="collapse" href="#collapse_{{yara_result['rule']}}" aria-expanded="false" aria-controls="collapse_{{yara_result['rule']}}">
                             String Matches
                         </a>
                     </h4>
                 </div>
-                <div id="collapse_{{yara_result['rule']}}" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="heading_{{yara_result['rule']}}">
+                <div id="collapse_{{yara_result['rule']}}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading_{{yara_result['rule']}}">
                     <div class="panel-body">
                         <ul class="list-group">
-                        {# context was added later, older alerts do not have it #}
-			{% if ace_config['gui'].getboolean('hide_intel') %}
-			    Hidden from public view.
-			{% else %}
-				{% if 'context' in yara_result %}
-				    {% for s in yara_result['context'] %}
+                        {% if ace_config['gui'].getboolean('hide_intel') %}
+                            <li class="list-group-item">Hidden from public view.</li>
+                        {% else %}
+                            {% if 'context' in yara_result %}
+                                {% for s in yara_result['context'] %}
                         {% if s | count > 0 %}
-                            <li class="list-group-item">position <b>{{s[0]}}</b> string $<b>{{s[1]}}</b> value <b>{{s[2]}}</b><pre>{{s[3]}}</pre>
+                            <li class="list-group-item">
+                                position <b>{{s[0]}}</b> string $<b>{{s[1]}}</b> value <b>{{s[2]}}</b>
+                                <pre>{{s[3]}}</pre>
+                                {% if s|length > 4 %}
+                                    Disassembly<pre>{{s[4]|safe}}</pre>
+                                {% endif %}
+                            </li>
                         {% endif %}
-                        {% if s|length > 4 %}
-                            Disassembly<pre>{{s[4]|safe}}</pre>
+                                {% endfor %}
+                            {% else %}
+                                {% for s in yara_result['strings'] %}
+                                {% if s | count > 0 %}
+                                    <li class="list-group-item">position <b>{{s[0]}}</b> string $<b>{{s[1]}}</b> value <b>{{s[2]}}</b></li>
+                                {% endif %}
+                                {% endfor %}
+                            {% endif %}
                         {% endif %}
-                        </li>
-				    {% endfor %}
-				{% else %}
-				    {% for s in yara_result['strings'] %}
-					{% if s | count > 0 %}
-					    <li class="list-group-item">position <b>{{s[0]}}</b> string $<b>{{s[1]}}</b> value <b>{{s[2]}}</b></li>
-					{% endif %}
-				    {% endfor %}
-				{% endif %}
-			{% endif %}
                         </ul>
                     </div>
                 </div>
@@ -68,3 +70,6 @@
     </div>
 </div>
 {% endfor %}
+{% else %}
+<div class="alert alert-info">No Yara scan results available.</div>
+{% endif %}

--- a/etc/logging_configs/.gitignore
+++ b/etc/logging_configs/.gitignore
@@ -1,8 +1,0 @@
-service_bro_http_collector.ini
-service_bro_smtp_collector.ini
-service_email_collector.ini
-service_engine.ini
-service_ews_collector.ini
-service_network_semaphore.ini
-service_remediation.ini
-service_yara.ini

--- a/saq/analysis/presenter.py
+++ b/saq/analysis/presenter.py
@@ -57,6 +57,9 @@ class AnalysisPresenter:
     @property
     def details(self):
         """Returns the details object to be used when displaying in the GUI."""
+        # Ensure details are loaded from external storage if needed
+        if not self._analysis.details and self._analysis.external_details_path:
+            self._analysis.load_details()
         return self._analysis.details
     
     # Delegate access to the underlying analysis object for any other properties needed
@@ -137,6 +140,13 @@ class YaraAnalysisPresenter(AnalysisPresenter):
     @property
     def template_path(self) -> str:
         return "analysis/yara_analysis.html"
+
+class YaraScanResults_v3_4_Presenter(AnalysisPresenter):
+    """Presenter for YaraScanResults_v3_4."""
+    
+    @property
+    def template_path(self) -> str:
+        return "analysis/yara_analysis_v3_4.html"
 
 
 class EmailAnalysisPresenter(AnalysisPresenter):
@@ -246,6 +256,7 @@ register_presenter("WhoisAnalysis", WhoisAnalysisPresenter)
 register_presenter("NetworkIdentifierAnalysis", NetworkIdentifierAnalysisPresenter)
 register_presenter("X509Analysis", X509AnalysisPresenter)
 register_presenter("YaraAnalysis", YaraAnalysisPresenter)
+register_presenter("YaraScanResults_v3_4", YaraScanResults_v3_4_Presenter)
 register_presenter("EmailAnalysis", EmailAnalysisPresenter)
 register_presenter("IPDBAnalysis", IPDBAnalysisPresenter)
 register_presenter("BinaryAnalysis", BinaryAnalysisPresenter)

--- a/saq/modules/file_analysis/yara.py
+++ b/saq/modules/file_analysis/yara.py
@@ -30,9 +30,11 @@ class YaraScanResults_v3_4(Analysis):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.details = {
-            "scan_results": []
-        }
+        # Only initialize details if they haven't been loaded from external storage
+        if self.details is None:
+            self.details = {
+                "scan_results": []
+            }
 
     @property
     def scan_results(self):


### PR DESCRIPTION
Yara scan results weren't displaying, so I made a few minor changes to fix.
- Update HTML template for Bootstrap 5 compatibility
- Fix data access w/ analysis_presenter.details
- Added simple error handling if missing scan results
- Fix YaraScanResults_v3_4 init logic