### PR TITLE
fix multi-architecture Docker build support for arm64/amd64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,13 +29,10 @@ ENV http_proxy=$http_proxy \
 RUN groupadd ace -g $SAQ_GROUP_ID && \
     useradd -g ace -m -s /bin/bash -u $SAQ_USER_ID ace
 
-# update sources and add microsoft repository
-# XXX do we still need the microsoft repo?
+# update sources to include contrib, non-free, and backports
+# Note: de4dot uses mono-runtime from Debian - dotnet runtime not needed.
 RUN sed -i -e '/^Components: main$/ s/$/ contrib non-free/' /etc/apt/sources.list.d/debian.sources && \
-    sed -i -e '/^Suites: bookworm bookworm-updates$/ s/$/ bookworm-backports/' /etc/apt/sources.list.d/debian.sources && \
-    wget https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O /tmp/packages-microsoft-prod.deb && \
-    dpkg -i /tmp/packages-microsoft-prod.deb && \
-    rm /tmp/packages-microsoft-prod.deb
+    sed -i -e '/^Suites: bookworm bookworm-updates$/ s/$/ bookworm-backports/' /etc/apt/sources.list.d/debian.sources
 
 # install system dependencies
 RUN apt-get update && \
@@ -56,7 +53,6 @@ RUN apt-get update && \
         dmg2img \
         dmg2img \
         dnsutils \
-        dotnet-runtime-9.0 \
         enchant-2 \
         exiftool \
         file \

--- a/phishkit/Dockerfile.phishkit
+++ b/phishkit/Dockerfile.phishkit
@@ -43,10 +43,11 @@ RUN apt-get update && apt-get install -y \
     ffmpeg \
     gnome-screenshot
 
-# install google chrome
-RUN curl -k -L https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb -o /tmp/google-chrome-stable_current_amd64.deb \
-    && dpkg -i /tmp/google-chrome-stable_current_amd64.deb \
-    && rm /tmp/google-chrome-stable_current_amd64.deb
+# install google chrome (architecture-aware)
+RUN ARCH=$(dpkg --print-architecture) && \
+    curl -k -L "https://dl.google.com/linux/direct/google-chrome-stable_current_${ARCH}.deb" -o /tmp/google-chrome-stable.deb && \
+    dpkg -i /tmp/google-chrome-stable.deb || apt-get install -f -y && \
+    rm /tmp/google-chrome-stable.deb
 
 # install python venv
 RUN python3 -m venv /opt/venv


### PR DESCRIPTION
Resolves build failures on arm64 (Apple Silicon) systems:

1. phishkit: Auto-detect architecture for Chrome download
 - Chrome packages are arch-specific (arm64 vs amd64)
 - Dockerfile.phishkit now uses dpkg --print-architecture

2. main: Remove Microsoft dotnet-runtime-9.0 dependency
 - dotnet-runtime-9.0 is not available for arm64
 - de4dot uses mono-runtime (available on arm64), not Microsoft's .NET
 - Removed Microsoft package repository (no longer needed)

Changes allow Docker builds to succeed on both arm64 and amd64 architectures without losing any functionality.

# Manual Testing

The following test script confirmed dotnet runtime was not needed on arm64. I did not run this on amd64 as I don't have an amd system readily available.

```python
"""
Test to verify de4dot analyzer does not require Microsoft's dotnet-runtime.

This test confirms that:
1. de4dot command is available (installed via apt-get)
2. de4dot uses mono-runtime, not Microsoft's dotnet-runtime
3. Microsoft's dotnet command should not be required
"""

import pytest
import subprocess
import shutil

def test_de4dot_exists():
    """Verify de4dot executable is available."""
    de4dot_path = shutil.which("de4dot")
    assert de4dot_path is not None, "de4dot command not found in PATH"
    assert "de4dot" in de4dot_path


def test_de4dot_runs():
    """Verify de4dot can execute (uses mono-runtime)."""
    result = subprocess.run(
        ["de4dot", "--help"],
        capture_output=True,
        text=True,
        timeout=5
    )
    # de4dot returns non-zero for --help, but should produce output
    assert "de4dot" in result.stdout or "de4dot" in result.stderr
    assert "Copyright" in result.stdout or "Copyright" in result.stderr


def test_mono_runtime_available():
    """Verify mono-runtime is available (required by de4dot)."""
    mono_path = shutil.which("mono")
    assert mono_path is not None, "mono command not found - de4dot requires mono-runtime"


def test_dotnet_runtime_not_required():
    """
    Verify Microsoft's dotnet command is not required for de4dot.

    This test documents that de4dot uses mono-runtime, not Microsoft's dotnet-runtime-9.0.
    If dotnet is installed, it's not being used by de4dot.
    """
    # de4dot should work regardless of whether dotnet is installed
    # This test simply documents that dotnet is not a dependency

    # Check if dotnet is installed (it shouldn't be, but we don't fail if it is)
    dotnet_path = shutil.which("dotnet")

    # The key assertion: de4dot must work even without dotnet
    result = subprocess.run(
        ["de4dot", "-d", "/dev/null"],  # Try to detect obfuscation on null file
        capture_output=True,
        text=True,
        timeout=5
    )

    # de4dot should run (even if it errors on /dev/null, it proves the executable works)
    # The point is that it doesn't require dotnet to execute
    assert result.returncode in [0, 1, 2], f"de4dot failed to execute: {result.stderr}"

    # Document the finding
    if dotnet_path:
        print(f"\nNote: dotnet found at {dotnet_path}, but de4dot doesn't use it")
    else:
        print("\nConfirmed: de4dot works without Microsoft's dotnet-runtime installed")


if __name__ == "__main__":
    # Allow running directly for quick testing
    print("Testing de4dot runtime dependencies...")
    print("\n1. Testing de4dot exists...")
    test_de4dot_exists()
    print("   ✓ de4dot found")

    print("\n2. Testing de4dot runs...")
    test_de4dot_runs()
    print("   ✓ de4dot runs successfully")

    print("\n3. Testing mono-runtime available...")
    test_mono_runtime_available()
    print("   ✓ mono-runtime found")

    print("\n4. Testing dotnet not required...")
    test_dotnet_runtime_not_required()
    print("   ✓ de4dot works without dotnet-runtime")

    print("\n✓ All tests passed!")
    print("\nConclusion:")
    print("  - de4dot uses mono-runtime (not Microsoft's dotnet-runtime)")
    print("  - dotnet-runtime-9.0 can be safely removed from Dockerfile")

```