### PR TITLE
Updates to bin/splunk.py helper script

### DIFF
--- a/bin/splunk.py
+++ b/bin/splunk.py
@@ -10,7 +10,7 @@ import sys
 import csv
 import json
 import re
-from configparser import SafeConfigParser
+from configparser import ConfigParser
 from getpass import getpass
 
 sys.path.append('lib')
@@ -159,7 +159,7 @@ app = '-'
 
 if os.path.exists(config_path) and not args.ignore_config:
     # load the settings from the configuration file
-    config = SafeConfigParser()
+    config = ConfigParser()
     config.read(config_path)
     try:
         uri = config.get(args.enviro, 'uri')

--- a/bin/splunk.py
+++ b/bin/splunk.py
@@ -13,15 +13,17 @@ import re
 from configparser import ConfigParser
 from getpass import getpass
 
-sys.path.append('lib')
-sys.path.append('.')
+sys.path.append("lib")
+sys.path.append(".")
 
 import saq.splunk as splunklib
+
 
 # encryption support
 def encrypt_password(password):
     from Crypto.Cipher import ARC4
-    from base64 import b64encode 
+    from base64 import b64encode
+
     memorized_password = getpass("Enter encryption password: ")
     memorized_password_check = getpass("Re-enter encryption password: ")
     if memorized_password != memorized_password_check:
@@ -31,78 +33,218 @@ def encrypt_password(password):
     cipher = ARC4.new(memorized_password)
     return b64encode(cipher.encrypt(password))
 
+
 def decrypt_password(encrypted_password):
     from Crypto.Cipher import ARC4
     from base64 import b64decode
+
     memorized_password = getpass("Enter encryption password: ")
     cipher = ARC4.new(memorized_password)
     return cipher.decrypt(b64decode(encrypted_password))
 
+
 parser = argparse.ArgumentParser()
-parser.add_argument('search', nargs=argparse.REMAINDER)
-parser.add_argument('-c', '--config', required=False, default=None, dest='config_path',
-    help="Path to optional configuration file.  Defaults to ~/.splunklib.ini")
-parser.add_argument('--ignore-config', required=False, default=False, action='store_true', dest='ignore_config',
-    help="Ignore any configuration files.")
-parser.add_argument('-v' , '--verbose', required=False, action='store_true', default=False, dest='verbose',
-    help="Log verbose messages.  Helps when debugging searches.")
-parser.add_argument('-q' , '--quiet', required=False, action='store_true', default=False, dest='quiet',
-    help="Only log error messages.")
+parser.add_argument("search", nargs=argparse.REMAINDER)
+parser.add_argument(
+    "-c",
+    "--config",
+    required=False,
+    default=None,
+    dest="config_path",
+    help="Path to optional configuration file.  Defaults to ~/.splunklib.ini",
+)
+parser.add_argument(
+    "--ignore-config",
+    required=False,
+    default=False,
+    action="store_true",
+    dest="ignore_config",
+    help="Ignore any configuration files.",
+)
+parser.add_argument(
+    "-v",
+    "--verbose",
+    required=False,
+    action="store_true",
+    default=False,
+    dest="verbose",
+    help="Log verbose messages.  Helps when debugging searches.",
+)
+parser.add_argument(
+    "-q",
+    "--quiet",
+    required=False,
+    action="store_true",
+    default=False,
+    dest="quiet",
+    help="Only log error messages.",
+)
 
-parser.add_argument('-U', '--uri', required=False, default=None, dest='uri',
-    help="The splunk URI to connect to.")
-parser.add_argument('-u', '--user', required=False, default=None, dest='username',
-    help="Your splunk username.")
-parser.add_argument('-p', '--password', required=False, default=False, action='store_true', dest='password',
-    help="Prompt for a password (will not echo.)")
-parser.add_argument('-m', '--max-result-count', required=False, default=1000, type=int, dest='max_result_count',
-    help="Maximum number of results to return.  Defaults to 1000")
-parser.add_argument('--proxy', required=False, default=None, dest='proxy',
-    help="Set proxy")
-parser.add_argument('--user_context', required=False, default=None, dest='user_context',
-    help="Set user context")
-parser.add_argument('--app', required=False, default=None, dest='app',
-    help="Set app context")
+parser.add_argument(
+    "-U",
+    "--uri",
+    required=False,
+    default=None,
+    dest="uri",
+    help="The splunk URI to connect to.",
+)
+parser.add_argument(
+    "-u",
+    "--user",
+    required=False,
+    default=None,
+    dest="username",
+    help="Your splunk username.",
+)
+parser.add_argument(
+    "-p",
+    "--password",
+    required=False,
+    default=False,
+    action="store_true",
+    dest="password",
+    help="Prompt for a password (will not echo.)",
+)
+parser.add_argument(
+    "-m",
+    "--max-result-count",
+    required=False,
+    default=1000,
+    type=int,
+    dest="max_result_count",
+    help="Maximum number of results to return.  Defaults to 1000",
+)
+parser.add_argument(
+    "--proxy", required=False, default=None, dest="proxy", help="Set proxy"
+)
+parser.add_argument(
+    "--user_context",
+    required=False,
+    default=None,
+    dest="user_context",
+    help="Set user context",
+)
+parser.add_argument(
+    "--app", required=False, default=None, dest="app", help="Set app context"
+)
 
-parser.add_argument('-s', '--start-time', required=False, default=None, dest='start_time',
-    help="Starting time in YYYY-MM-DD HH:MM:SS format.  Defaults to 24 hours before now.")
-parser.add_argument('-e', '--end-time', required=False, default=None, dest='end_time',
-    help="Ending time in YYYY-MM-DD HH:MM:SS format.  Defaults to now.")
+parser.add_argument(
+    "-s",
+    "--start-time",
+    required=False,
+    default=None,
+    dest="start_time",
+    help="Starting time in YYYY-MM-DD HH:MM:SS format.  Defaults to 24 hours before now.",
+)
+parser.add_argument(
+    "-e",
+    "--end-time",
+    required=False,
+    default=None,
+    dest="end_time",
+    help="Ending time in YYYY-MM-DD HH:MM:SS format.  Defaults to now.",
+)
 
-parser.add_argument('-S', '--relative-start-time', required=False, default=None, dest='relative_start_time',
-    help="Specify the starting time as a time relative to now in DD:HH:MM:SS format.")
-parser.add_argument('-E', '--relative-end-time', required=False, default=None, dest='relative_end_time',
-    help="Specify the ending time as a time relative to now in DD:HH:MM:SS format.")
-parser.add_argument('--enviro', action='store', required=True, default='production', dest='enviro',
-    help="Specify which splunk environment to query (default=production). These are the sections defined in your config file.")
+parser.add_argument(
+    "-S",
+    "--relative-start-time",
+    required=False,
+    default=None,
+    dest="relative_start_time",
+    help="Specify the starting time as a time relative to now in DD:HH:MM:SS format.",
+)
+parser.add_argument(
+    "-E",
+    "--relative-end-time",
+    required=False,
+    default=None,
+    dest="relative_end_time",
+    help="Specify the ending time as a time relative to now in DD:HH:MM:SS format.",
+)
+parser.add_argument(
+    "--enviro",
+    action="store",
+    required=True,
+    default="production",
+    dest="enviro",
+    help="Specify which splunk environment to query (default=production). These are the sections defined in your config file.",
+)
 
 # the options only apply in the default csv mode
-parser.add_argument('--headers', required=False, default=False, action='store_true', dest='headers',
-    help="Display headers in CSV output mode.")
+parser.add_argument(
+    "--headers",
+    required=False,
+    default=False,
+    action="store_true",
+    dest="headers",
+    help="Display headers in CSV output mode.",
+)
 
 # json display option
-parser.add_argument('--json', required=False, default=False, action='store_true', dest='json',
-    help="Output in JSON instead of CSV")
+parser.add_argument(
+    "--json",
+    required=False,
+    default=False,
+    action="store_true",
+    dest="json",
+    help="Output in JSON instead of CSV",
+)
 
 # redirect to a file
-parser.add_argument('-o', '--output', required=False, default=None, dest='output',
-    help="Send output to a file.  Default is stdout.")
+parser.add_argument(
+    "-o",
+    "--output",
+    required=False,
+    default=None,
+    dest="output",
+    help="Send output to a file.  Default is stdout.",
+)
 
 # save the given configuration to file for use later
-parser.add_argument('--save-config', required=False, default=False, action='store_true', dest='save_config',
-    help="Save the given configuration options to ~/.splunklib")
-parser.add_argument('--encrypt', required=False, default=False, action='store_true', dest='encrypt_password',
-    help="Encrypt your splunk password with another password.")
+parser.add_argument(
+    "--save-config",
+    required=False,
+    default=False,
+    action="store_true",
+    dest="save_config",
+    help="Save the given configuration options to ~/.splunklib",
+)
+parser.add_argument(
+    "--encrypt",
+    required=False,
+    default=False,
+    action="store_true",
+    dest="encrypt_password",
+    help="Encrypt your splunk password with another password.",
+)
 
-parser.add_argument('--search-file', required=False, default=False, action='store', dest='search_file',
-    help="File containing the search query.")
+parser.add_argument(
+    "--search-file",
+    required=False,
+    default=False,
+    action="store",
+    dest="search_file",
+    help="File containing the search query.",
+)
 
 # adding this for use with url_click cloudphish hunt
-parser.add_argument('-i', '--use-index-time', required=False, default=None, action='store_true', dest='use_index_time',
-        help="Use __index time specs instead.")
+parser.add_argument(
+    "-i",
+    "--use-index-time",
+    required=False,
+    default=None,
+    action="store_true",
+    dest="use_index_time",
+    help="Use __index time specs instead.",
+)
 
-parser.add_argument('--query-timeout', required=False, default=None, dest='query_timeout',
-                    help="Amount of time (in HH:MM:SS format) until a query times out.  Defaults to 30 minutes.")
+parser.add_argument(
+    "--query-timeout",
+    required=False,
+    default=None,
+    dest="query_timeout",
+    help="Amount of time (in HH:MM:SS format) until a query times out.  Defaults to 30 minutes.",
+)
 
 args = parser.parse_args()
 
@@ -112,39 +254,39 @@ if args.quiet:
 if args.verbose:
     logging_level = logging.DEBUG
 logging.basicConfig(
-    format='[%(asctime)s] [%(filename)s:%(lineno)d] [%(threadName)s] [%(levelname)s] - %(message)s', 
-    level=logging_level)
+    format="[%(asctime)s] [%(filename)s:%(lineno)d] [%(threadName)s] [%(levelname)s] - %(message)s",
+    level=logging_level,
+)
 
 # are we saving the configuration?
 if args.save_config:
-    config_path = os.path.join(os.path.expanduser('~'), '.splunklib.ini')
-    with open(config_path, 'w') as fp:
-        fp.write('[production]\n')
+    config_path = os.path.join(os.path.expanduser("~"), ".splunklib.ini")
+    with open(config_path, "w") as fp:
+        fp.write("[production]\n")
         if args.uri is not None:
-            fp.write('uri = {0}\n'.format(args.uri))
+            fp.write("uri = {0}\n".format(args.uri))
         if args.username is not None:
-            fp.write('username = {0}\n'.format(args.username))
+            fp.write("username = {0}\n".format(args.username))
         if args.password:
             password = getpass("Enter password: ")
 
             if args.encrypt_password:
                 encrypted_password = encrypt_password(password)
                 logging.debug("encrypted_password = {0}".format(encrypted_password))
-                fp.write('encrypted_password = {0}\n'.format(encrypted_password))
+                fp.write("encrypted_password = {0}\n".format(encrypted_password))
             else:
-                fp.write('password = {0}\n'.format(password))
+                fp.write("password = {0}\n".format(password))
                 logging.warning("saving PLAIN TEXT PASSWORD (use --encrypt option)")
 
-
         if args.max_result_count is not None:
-            fp.write('max_result_count = {0}\n'.format(str(args.max_result_count)))
+            fp.write("max_result_count = {0}\n".format(str(args.max_result_count)))
 
-    os.chmod(config_path, 0o600) # sane permissions
+    os.chmod(config_path, 0o600)  # sane permissions
     logging.debug("updated configuration")
     sys.exit(0)
 
 # do we have a configuration file?
-config_path = os.path.join(os.path.expanduser('~'), '.splunklib.ini')
+config_path = os.path.join(os.path.expanduser("~"), ".splunklib.ini")
 if args.config_path is not None:
     config_path = args.config_path
 
@@ -154,40 +296,44 @@ encrypted_password = None
 password = None
 max_result_count = 1000
 proxy = None
-user_context = '-'
-app = '-'
+user_context = "-"
+app = "-"
 
 if os.path.exists(config_path) and not args.ignore_config:
     # load the settings from the configuration file
     config = ConfigParser()
     config.read(config_path)
     try:
-        uri = config.get(args.enviro, 'uri')
-        username = config.get(args.enviro, 'username')
-        proxy = config.get(args.enviro, 'proxy')
-        user_context = config.get(args.enviro, 'user_context')
-        app = config.get(args.enviro, 'app')
-        if config.has_option(args.enviro, 'encrypted_password'):
-            encrypted_password = config.get(args.enviro, 'encrypted_password')
+        uri = config.get(args.enviro, "uri")
+        username = config.get(args.enviro, "username")
+        proxy = config.get(args.enviro, "proxy")
+        user_context = config.get(args.enviro, "user_context")
+        app = config.get(args.enviro, "app")
+        if config.has_option(args.enviro, "encrypted_password"):
+            encrypted_password = config.get(args.enviro, "encrypted_password")
         else:
-            if config.has_option(args.enviro, 'password'):
+            if config.has_option(args.enviro, "password"):
                 # make sure permissions are sane
                 if os.stat(config_path).st_mode & stat.S_IROTH:
-                    sys.stderr.write("""
+                    sys.stderr.write(
+                        """
 *** HEY CLOWN ***
 your file permissions on {0} allow anyone to read your plain text splunk password!
 use the --save-config option with --encrypt to save your configuration with an encrypted password or chmod o-rwx this file
 so that other people cannot read it
 *** END CLOWN MESSAGE ***
-""".format(config_path))
+""".format(config_path)
+                    )
 
-                password = config.get(args.enviro, 'password')
+                password = config.get(args.enviro, "password")
 
-        if config.has_option(args.enviro, 'max_result_count'):
-            max_result_count = config.getint(args.enviro, 'max_result_count')
+        if config.has_option(args.enviro, "max_result_count"):
+            max_result_count = config.getint(args.enviro, "max_result_count")
 
     except Exception as e:
-        logging.warning("invalid configuration file {0}: {1}".format(config_path, str(e)))
+        logging.warning(
+            "invalid configuration file {0}: {1}".format(config_path, str(e))
+        )
 
 # command line options override configuration values
 if args.uri is not None:
@@ -223,19 +369,21 @@ if password is None:
 search_text = None
 if args.search_file:
     if os.path.isfile(args.search_file):
-        with open(args.search_file, 'r') as fp:
+        with open(args.search_file, "r") as fp:
             search_text = fp.read()
             # comments in the search files are lines that start with #
-            search_text = re.sub(r'^\s*#.*$', '', search_text, count=0, flags=re.MULTILINE)
+            search_text = re.sub(
+                r"^\s*#.*$", "", search_text, count=0, flags=re.MULTILINE
+            )
             # put it all on one line for splunk
             # we don't *need* to do this except for keeping the logs clean
-            search_text = re.sub(r'\n', ' ', search_text, count=0)
+            search_text = re.sub(r"\n", " ", search_text, count=0)
         # removeing time_spec allows us to pass hunt files from the cli
-        if '{time_spec}' in search_text:
+        if "{time_spec}" in search_text:
             search_text = search_text.format(time_spec="")
         args.search = search_text
     else:
-        logging.fatal("search file does not exist") 
+        logging.fatal("search file does not exist")
 if len(args.search) < 1:
     logging.fatal("missing search")
     fatal = True
@@ -247,12 +395,12 @@ query = None
 if args.search_file:
     query = search_text
 else:
-    query = ' '.join(args.search)
+    query = " ".join(args.search)
 
 # figure out the time range given the options
 start_time = None
 end_time = None
-datetime_format = '%Y-%m-%d %H:%M:%S'
+datetime_format = "%Y-%m-%d %H:%M:%S"
 
 if args.start_time is not None:
     start_time = datetime.datetime.strptime(args.start_time, datetime_format)
@@ -261,48 +409,52 @@ if args.end_time is not None:
     end_time = datetime.datetime.strptime(args.end_time, datetime_format)
 
 if args.relative_start_time is not None:
-    start_time = datetime.datetime.now() - splunklib.create_timedelta(args.relative_start_time)
+    start_time = datetime.datetime.now() - splunklib.create_timedelta(
+        args.relative_start_time
+    )
 if args.relative_end_time is not None:
-    end_time = datetime.datetime.now() - splunklib.create_timedelta(args.relative_end_time)
+    end_time = datetime.datetime.now() - splunklib.create_timedelta(
+        args.relative_end_time
+    )
 
 if start_time is not None and end_time is None:
     end_time = datetime.datetime.now()
 
-if start_time is None and 'earliest' not in query.lower():
+if start_time is None and "earliest" not in query.lower():
     logging.debug("defaulting to past 24 hours")
-    start_time = datetime.datetime.now() - splunklib.create_timedelta('00:24:00:00')
+    start_time = datetime.datetime.now() - splunklib.create_timedelta("00:24:00:00")
     end_time = datetime.datetime.now()
 
 searcher = splunklib.SplunkQueryObject(
     uri,
     username,
     password,
-    proxies = {'http': proxy, 'https': proxy} if proxy else {},
-    user_context = user_context,
-    app = app,
+    proxies={"http": proxy, "https": proxy} if proxy else {},
+    user_context=user_context,
+    app=app,
 )
 
 search_result = searcher.query(
     query,
-    start = start_time,
-    end = end_time,
-    limit = max_result_count,
-    timeout = args.query_timeout if args.query_timeout else '00:30:00',
-    use_index_time = args.use_index_time,
+    start=start_time,
+    end=end_time,
+    limit=max_result_count,
+    timeout=args.query_timeout if args.query_timeout else "00:30:00",
+    use_index_time=args.use_index_time,
 )
 
 output_fp = sys.stdout
 if args.output:
-    output_fp = open(args.output, 'w', encoding='utf-8')
+    output_fp = open(args.output, "w", encoding="utf-8")
 
 # JSON output
 if args.json:
     data = {
-        'search': query,
-        'username': username,
-        'uri': uri,
-        'max_result_count': max_result_count,
-        'result': search_result,
+        "search": query,
+        "username": username,
+        "uri": uri,
+        "max_result_count": max_result_count,
+        "result": search_result,
     }
     json.dump(data, output_fp)
 


### PR DESCRIPTION
This PR updates the `bin/splunk.py` helper script so that it:

- Directly uses ACE config instead of looking for `~/.splunklib.ini`
- Supports the use of Splunk tokens instead of only username/password