### PR TITLE
SplunkAPIAnalyzer adjustments

### DIFF
--- a/etc/saq.splunk.default.yaml
+++ b/etc/saq.splunk.default.yaml
@@ -1,5 +1,5 @@
-api_query_defaults_splunk:
-  name: splunk
+api_query_defaults_default:
+  name: default
   wide_duration_before: "01:00:00:00"
   wide_duration_after: "01:00:00:00"
   narrow_duration_before: "00:01:00:00"
@@ -55,3 +55,4 @@ hunt_type_splunk:
 
 config:
   splunk_local: etc/saq.splunk.yaml
+  splunk_modules: etc/saq.splunk_modules.yaml

--- a/etc/saq.splunk_modules.yaml
+++ b/etc/saq.splunk_modules.yaml
@@ -1,0 +1,35 @@
+# Example analysis module definition
+#
+# NOTE: After creating a YAML-based analysis module, you must also add it to
+# one of the "module groups", such as "module_group_correlation". Check the
+# saq.default.yaml config file for how those are configured.
+#
+# analysis_module_proxy_domain_lookup:
+#   name: proxy_domain_lookup
+#   python_module: saq.modules.splunk
+#   python_class: SplunkAPIAnalyzer
+#   enabled: true
+#   api_name: default
+#   valid_observable_types: [domain]
+#   question: "Was this domain seen in proxy logs?"
+#   summary: "Proxy correlation"
+#   query: |
+#     index=network_zscaler_web (transport=HTTPS OR transport=HTTP) hostname="<O_VALUE>"
+#     | eval full_url = lower(transport) . "://" . url
+#   use_index_time: true
+#   narrow_duration_before: "00:24:00:00"
+#   narrow_duration_after: "00:24:00:00"
+#   observable_mapping:
+#     - field: src_ip
+#       type: ip
+#       display_type: Source IP
+#     - field: src_translated_ip
+#       type: ip
+#       display_type: Source IP
+#     - field: dest_ip
+#       type: ip
+#       display_type: Destination IP
+#     - field: full_url
+#       type: url
+#     - field: user
+#       type: email_address

--- a/etc/saq.unittest.default.yaml
+++ b/etc/saq.unittest.default.yaml
@@ -678,4 +678,23 @@ api_query_defaults_test_api:
   use_index_time: true
 
 splunk_config_default:
+  name: default
+  enabled: true
   host: localhost
+  port: 443
+  username:
+  password:
+  token:
+  timezone: UTC
+  performance_logging_dir: splunk_perf
+
+splunk_config_test_api:
+  name: test_api
+  enabled: true
+  host: localhost
+  port: 443
+  username:
+  password:
+  token:
+  timezone: UTC
+  performance_logging_dir: splunk_perf

--- a/tests/saq/modules/test_splunk.py
+++ b/tests/saq/modules/test_splunk.py
@@ -3,11 +3,25 @@ from unittest.mock import Mock, patch
 import pytest
 
 from saq.configuration.config import get_analysis_module_config
-from saq.constants import ANALYSIS_MODULE_SPLUNK_API, F_EMAIL_SUBJECT
+from saq.constants import ANALYSIS_MODULE_SPLUNK_API, F_EMAIL_SUBJECT, F_IPV4
 from saq.analysis import RootAnalysis
-from saq.modules.api_analysis import AnalysisDelay
-from saq.modules.splunk import SplunkAPIAnalyzer, SplunkAPIAnalysis
+from saq.modules.api_analysis import AnalysisDelay, APIObservableMapping
+from saq.modules.splunk import SplunkAPIAnalyzer, SplunkAPIAnalysis, SplunkAPIAnalyzerConfig
 from tests.saq.mock_datetime import MOCK_NOW
+
+
+class MockJobsDict:
+    """Mock for Splunk client.jobs with dict-like access."""
+    def __init__(self):
+        self._jobs = {}
+
+    def __getitem__(self, name):
+        if name not in self._jobs:
+            raise KeyError(name)
+        return self._jobs[name]
+
+    def add(self, job):
+        self._jobs[job.name] = job
 
 
 class MockSplunk:
@@ -19,6 +33,13 @@ class MockSplunk:
         self.start_time = None
         self.running_start_time = None
         self.end_time = None
+        # Mock client with jobs dict for job lookup
+        self.client = Mock()
+        self.client.jobs = MockJobsDict()
+
+    def add_mock_job(self, job):
+        """Add a job to the mock jobs dict for lookup."""
+        self.client.jobs.add(job)
 
     def encoded_query_link(self, query, start_time=None, end_time=None):
         return query + ' world'
@@ -75,15 +96,17 @@ def test_splunk_api_analyzer_execute_query(test_context):
         analyzer.target_query = 'hello'
         analyzer.analysis = SplunkAPIAnalysis()
 
-        # create initial mock job
+        # create initial mock job and add it to mock splunk's job dict
         mock_job = Mock()
         mock_job.name = "0"
-        analyzer.analysis.search_id = mock_job
+        mock_splunk.add_mock_job(mock_job)
+        analyzer.analysis.search_id = mock_job  # This now stores "0" (string)
 
         # test completed query
         result = analyzer.execute_query()
         assert result == 'hello'
-        assert analyzer.analysis.search_id.name == "1"
+        # search_id now stores the job name as a string, not the Job object
+        assert analyzer.analysis.search_id == "1"
 
         # test delay
         analyzer.target_query = None
@@ -130,3 +153,176 @@ def test_splunk_api_analyzer_escape_value(test_context):
         analyzer.build_target_query(observable, source_event_time=datetime.datetime.now())
 
         assert analyzer.target_query == 'Hello, \\"World\\"'
+
+
+@pytest.mark.unit
+def test_api_observable_mapping_model():
+    """Test APIObservableMapping Pydantic model validation."""
+    # Test with single field
+    mapping = APIObservableMapping(field="src_ip", type="ipv4")
+    assert mapping.get_fields() == ["src_ip"]
+    assert mapping.tags == []
+    assert mapping.directives == []
+
+    # Test with multiple fields
+    mapping = APIObservableMapping(fields=["user", "username"], type="user")
+    assert mapping.get_fields() == ["user", "username"]
+
+    # Test with tags and directives
+    mapping = APIObservableMapping(
+        field="src_ip",
+        type="ipv4",
+        tags=["external", "suspicious"],
+        directives=["analyze_ip"],
+        time=True,
+        ignored_values=["0.0.0.0", "127.0.0.1"],
+        display_type="custom_ip",
+        display_value="Source IP"
+    )
+    assert mapping.tags == ["external", "suspicious"]
+    assert mapping.directives == ["analyze_ip"]
+    assert mapping.time is True
+    assert mapping.ignored_values == ["0.0.0.0", "127.0.0.1"]
+    assert mapping.display_type == "custom_ip"
+    assert mapping.display_value == "Source IP"
+
+    # Test validation error when neither field nor fields is specified
+    with pytest.raises(ValueError, match="Either 'field' or 'fields' must be specified"):
+        APIObservableMapping(type="ipv4")
+
+
+@pytest.mark.unit
+def test_extract_result_observables_with_tags(test_context):
+    """Test that extract_result_observables applies tags and directives."""
+    with patch("saq.modules.splunk.SplunkClient") as mock_splunk_client:
+        mock_splunk = MockSplunk()
+        mock_splunk_client.return_value = mock_splunk
+
+        # Create a config with observable mapping that includes tags
+        config = SplunkAPIAnalyzerConfig(
+            name="test_splunk",
+            python_module="saq.modules.splunk",
+            python_class="SplunkAPIAnalyzer",
+            enabled=True,
+            question="Test question?",
+            summary="Test summary",
+            api_name="test_api",
+            query="index=test",
+            observable_mapping=[
+                APIObservableMapping(
+                    field="src_ip",
+                    type="ipv4",
+                    tags=["external", "from_splunk"],
+                    directives=["analyze"],
+                    time=True
+                )
+            ]
+        )
+
+        analyzer = SplunkAPIAnalyzer(context=test_context, config=config)
+
+        # Create a mock analysis
+        root = RootAnalysis()
+        observable = root.add_observable_by_spec(F_IPV4, "1.2.3.4")
+        analysis = analyzer.create_analysis(observable)
+
+        # Mock result from Splunk
+        result = {"src_ip": "10.0.0.1", "other_field": "ignored"}
+        result_time = datetime.datetime.now()
+
+        # Extract observables
+        analyzer.extract_result_observables(analysis, result, observable, result_time)
+
+        # Verify observable was created with tags and directives
+        assert len(analysis.observables) == 1
+        new_obs = analysis.observables[0]
+        assert new_obs.value == "10.0.0.1"
+        assert "external" in new_obs.tags
+        assert "from_splunk" in new_obs.tags
+        assert "analyze" in new_obs.directives
+        assert new_obs.time == result_time
+
+
+@pytest.mark.unit
+def test_extract_result_observables_multiple_fields(test_context):
+    """Test that multiple fields mapping uses first non-null value."""
+    with patch("saq.modules.splunk.SplunkClient") as mock_splunk_client:
+        mock_splunk = MockSplunk()
+        mock_splunk_client.return_value = mock_splunk
+
+        config = SplunkAPIAnalyzerConfig(
+            name="test_splunk",
+            python_module="saq.modules.splunk",
+            python_class="SplunkAPIAnalyzer",
+            enabled=True,
+            question="Test question?",
+            summary="Test summary",
+            api_name="test_api",
+            query="index=test",
+            observable_mapping=[
+                APIObservableMapping(
+                    fields=["user", "username", "account"],
+                    type="user"
+                )
+            ]
+        )
+
+        analyzer = SplunkAPIAnalyzer(context=test_context, config=config)
+
+        root = RootAnalysis()
+        observable = root.add_observable_by_spec(F_IPV4, "1.2.3.4")
+        analysis = analyzer.create_analysis(observable)
+
+        # First field is null, second has value
+        result = {"user": None, "username": "jsmith", "account": "admin"}
+
+        analyzer.extract_result_observables(analysis, result, observable)
+
+        assert len(analysis.observables) == 1
+        assert analysis.observables[0].value == "jsmith"
+
+
+@pytest.mark.unit
+def test_extract_result_observables_ignored_values(test_context):
+    """Test that ignored values are skipped."""
+    with patch("saq.modules.splunk.SplunkClient") as mock_splunk_client:
+        mock_splunk = MockSplunk()
+        mock_splunk_client.return_value = mock_splunk
+
+        config = SplunkAPIAnalyzerConfig(
+            name="test_splunk",
+            python_module="saq.modules.splunk",
+            python_class="SplunkAPIAnalyzer",
+            enabled=True,
+            question="Test question?",
+            summary="Test summary",
+            api_name="test_api",
+            query="index=test",
+            observable_mapping=[
+                APIObservableMapping(
+                    field="src_ip",
+                    type="ipv4",
+                    ignored_values=["0.0.0.0", "127.0.0.1"]
+                )
+            ]
+        )
+
+        analyzer = SplunkAPIAnalyzer(context=test_context, config=config)
+
+        root = RootAnalysis()
+        observable = root.add_observable_by_spec(F_IPV4, "1.2.3.4")
+        analysis = analyzer.create_analysis(observable)
+
+        # Value is in ignored list
+        result = {"src_ip": "127.0.0.1"}
+        analyzer.extract_result_observables(analysis, result, observable)
+
+        # No observable should be created
+        assert len(analysis.observables) == 0
+
+        # Now with a valid value
+        result = {"src_ip": "10.0.0.1"}
+        analyzer.extract_result_observables(analysis, result, observable)
+
+        assert len(analysis.observables) == 1
+        assert analysis.observables[0].value == "10.0.0.1"


### PR DESCRIPTION
This PR updates the `SplunkAPIAnalyzer` to fix an issue with how it gets the search ID now that we're using the Splunk SDK instead of our own custom implementation.

It also updates the `BaseAPIAnalyzer` to use similar `observable_mapping` as hunts use. This now allows us to apply tags, directives, and display name/type to the mapped observables.