### PR TITLE
Allows selecting directives in Add Observable dialog

### DIFF
--- a/app/analysis/views/index.py
+++ b/app/analysis/views/index.py
@@ -11,7 +11,7 @@ from saq.analysis.observable import Observable
 from saq.analysis.presenter import create_analysis_presenter, create_observable_presenter
 from saq.analysis.root import RootAnalysis
 from saq.configuration.config import get_config
-from saq.constants import CLOSED_EVENT_LIMIT, F_FILE, VALID_OBSERVABLE_TYPES
+from saq.constants import CLOSED_EVENT_LIMIT, DIRECTIVE_DESCRIPTIONS, F_FILE, GUI_DIRECTIVES, VALID_OBSERVABLE_TYPES
 from saq.database.model import Campaign, Comment, Company, Malware, User, Event
 from saq.database.pool import get_db
 from saq.database.util.observable_detection import get_all_observable_detections
@@ -377,6 +377,7 @@ def index():
         db=get_db(),
         current_time=datetime.now(),
         observable_types=VALID_OBSERVABLE_TYPES,
+        directives={directive: DIRECTIVE_DESCRIPTIONS[directive] for directive in GUI_DIRECTIVES},
         display_tree=display_tree,
         prune_display_tree=session['prune'],
         prune_volatile=session['prune_volatile'],

--- a/app/static/js/saq_analysis.js
+++ b/app/static/js/saq_analysis.js
@@ -59,9 +59,40 @@ $(document).ready(function() {
         $("#option_" + disposition).click();
     });
 
+    // Reset directive selection when add observable modal opens
+    $('#add_observable_modal').on('show.bs.modal', function () {
+        $("#add_observable_directives_multiselect").val([]);
+        $("#add_observable_directives_text").val("");
+        $("#add_observable_directives_multiselect_container").show();
+        $("#add_observable_directives_text_container").hide();
+    });
+
     $("#add_observable_type").change(function (e) {
         const observable_type = $("#add_observable_type option:selected").text();
         var add_observable_input = document.getElementById("add_observable_value");
+        var directives_multiselect = $("#add_observable_directives_multiselect");
+        var directives_multiselect_container = $("#add_observable_directives_multiselect_container");
+        var directives_text_container = $("#add_observable_directives_text_container");
+
+        // Reset directive selection
+        directives_multiselect.val([]);
+        $("#add_observable_directives_text").val("");
+
+        // Toggle directive input type based on observable type
+        if (['email_address', 'user'].includes(observable_type)) {
+            directives_multiselect_container.hide();
+            directives_text_container.show();
+        } else {
+            directives_text_container.hide();
+            directives_multiselect_container.show();
+        }
+
+        // Auto-select 'sandbox' for file types
+        if (observable_type === 'file') {
+            directives_multiselect.val(['sandbox']);
+        }
+
+        // Handle observable value input type changes
         if (!['email_conversation', 'email_delivery', 'ipv4_conversation', 'ipv4_full_conversation', 'file'].includes(observable_type)) {
             add_observable_input.parentNode.removeChild(add_observable_input);
             $("#add_observable_value_content").append('<input type="text" class="form-control" id="add_observable_value" name="add_observable_value" value="" placeholder="Enter Value"/>');

--- a/app/templates/analysis/index.html
+++ b/app/templates/analysis/index.html
@@ -141,6 +141,21 @@
                     <input type="text" class="form-control" id="add_observable_time" name="add_observable_time" value="" placeholder="YYYY-MM-DD HH:MM:SS"/>
                     </div>
                 </div>
+                <div class="row" style="margin-top: 10px;">
+                    <div class="col">
+                    Directives (optional)
+                    <div id="add_observable_directives_text_container" style="display: none">
+                        <input class="form-control" type="text" name="add_observable_directives" id="add_observable_directives_text" value="" placeholder="Comma-separated directives">
+                    </div>
+                    <div id="add_observable_directives_multiselect_container">
+                        <select class="form-select" name="add_observable_directives[]" id="add_observable_directives_multiselect" multiple>
+                        {% for directive in directives %}
+                            <option value="{{directive}}" title="{{ directives[directive] }}">{{directive}}</option>
+                        {% endfor %}
+                        </select>
+                    </div>
+                    </div>
+                </div>
             </div>
             <div class="modal-footer">
                 <input type="hidden" name="alert_uuid" value="{{alert.uuid}}"></input>


### PR DESCRIPTION
This updates the "Add Observable" dialog so that you can optionally select directives just like you can on the Manual Analysis page when creating a new manual alert. This lets you do things like add a `file_location` observable to an existing alert and select the `collect_file` directive to pull the file into an alert.

<img width="494" height="301" alt="image" src="https://github.com/user-attachments/assets/10ffbc07-dc64-4ac4-abd7-b4b5c439123f" />
