### PR TITLE
Fixes and improves Jump To Analysis links

### DIFF
--- a/app/static/css/saq.css
+++ b/app/static/css/saq.css
@@ -511,3 +511,13 @@ nav[data-toggle="toc"] {
     display: none;
   }
 }
+
+/* Jump To Analysis highlight animation */
+@keyframes highlight-flash {
+    0% { background-color: #ffeb3b; }
+    100% { background-color: transparent; }
+}
+
+.jump-highlight {
+    animation: highlight-flash 2.0s ease-out;
+}

--- a/app/static/js/saq_analysis.js
+++ b/app/static/js/saq_analysis.js
@@ -266,6 +266,49 @@ $(document).ready(function() {
         timeFormat: 'HH:mm:ss'
     });
 
+    // Handle "Jump To Analysis" links with smooth scrolling and highlight
+    function scrollToAndHighlight(targetId) {
+        var target = document.getElementById(targetId);
+        if (target) {
+            target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            target.classList.add('jump-highlight');
+            setTimeout(function() {
+                target.classList.remove('jump-highlight');
+            }, 1500);
+        }
+    }
+
+    // Handle clicks on "Jump To Analysis" links
+    $(document).on('click', 'a[href^="#"]', function(e) {
+        var href = $(this).attr('href');
+        if (href && href.length > 1) {
+            var targetId = href.substring(1);
+            var target = document.getElementById(targetId);
+            if (target) {
+                e.preventDefault();
+                history.pushState(null, null, href);
+                scrollToAndHighlight(targetId);
+            }
+        }
+    });
+
+    // Handle initial page load with hash in URL
+    if (window.location.hash && window.location.hash.length > 1) {
+        function tryScrollToHash() {
+            setTimeout(function() {
+                scrollToAndHighlight(window.location.hash.substring(1));
+            }, 100);
+        }
+
+        if (document.readyState === 'complete') {
+            // Page already fully loaded, scroll now
+            tryScrollToHash();
+        } else {
+            // Wait for page to finish loading
+            $(window).on('load', tryScrollToHash);
+        }
+    }
+
 });
 
 // attachment downloading

--- a/app/templates/analysis/alert.html
+++ b/app/templates/analysis/alert.html
@@ -245,7 +245,7 @@
 {% macro display_tree_node(node) %}
     {% if (not prune_display_tree or node.visible) and node.should_render %}
         {% if not node.is_root_analysis %}
-            <li class="saq-analysis-li">
+            <li class="saq-analysis-li" id="{% if not node.is_analysis and node.reference_node is none %}{{node.obj.uuid}}{% else %}{{node.uuid}}{% endif %}">
                 {# add collapse button if collapsible #}
                 {% if node.is_collapsible(prune_display_tree) %}
                     <i class="toggle-icon bi bi-chevron-down" onclick=collapseTree(this)></i>
@@ -311,7 +311,7 @@
         {# recursively display child nodes #}
         {% if not node.is_analysis and node.reference_node is not none %}
             {% if node.reference_node.is_collapsible(prune_display_tree) %} 
-                <ul><li class="saq-analysis-li"><span class="saq-analysis-bullet">&bull;</span><a href="#{{node.reference_node.uuid}}">Jump To Analysis</a></li></ul>
+                <ul><li class="saq-analysis-li"><span class="saq-analysis-bullet">&bull;</span><a href="#{{node.reference_node.obj.uuid}}">Jump To Analysis</a></li></ul>
             {% endif %}
         {% else %}
             <ul>


### PR DESCRIPTION
This PR fixes the "Jump To Analysis" links in the nested analysis trees. In addition, it now uses JavaScript to smooth scroll to the analysis node and includes a brief highlight animation on the jumped-to node to draw your attention to where you jumped. This includes if you were to bookmark an alert link that has the analysis node UUID in the URL. When you load that type of URL, it will automatically scroll to the appropriate place within the alert.