### PR TITLE
Initial FastAPI implementation

### DIFF
--- a/ace_api.py
+++ b/ace_api.py
@@ -237,7 +237,7 @@ def _execute_api_call(command,
     if timeout is not None:
         kwargs['timeout'] = timeout
     if api_key is not None:
-        kwargs['headers'] = { "x-ice-auth": api_key }
+        kwargs['headers'] = { "x-ace-auth": api_key }
 
     response = func('https://{}/api/{}'.format(remote_host, command), **kwargs)
     response.raise_for_status()

--- a/aceapi/auth.py
+++ b/aceapi/auth.py
@@ -23,7 +23,7 @@ KEY_API_AUTH_NAME = "name"
 API_AUTH_TYPE_CONFIG = "config"
 API_AUTH_TYPE_USER = "user"
 
-API_HEADER_NAME = "x-ice-auth"
+API_HEADER_NAME = "x-ace-auth"
 
 def _get_config_api_key_match(auth_sha256: str) -> ApiAuthResult:
     """Returns an ApiAuthResult object if the given auth token is stored as a configuration value under [apikeys], None otherwise."""

--- a/aceapi_v2/__init__.py
+++ b/aceapi_v2/__init__.py
@@ -1,0 +1,1 @@
+from aceapi_v2.application import create_app

--- a/aceapi_v2/application.py
+++ b/aceapi_v2/application.py
@@ -1,0 +1,28 @@
+"""FastAPI application factory for ACE API v2."""
+
+from fastapi import FastAPI
+
+from aceapi_v2.auth.router import router as auth_router
+from aceapi_v2.health.router import router as health_router
+from aceapi_v2.observable_types.router import router as observable_types_router
+
+
+def create_app() -> FastAPI:
+    """Create and configure the FastAPI application."""
+    app = FastAPI(
+        title="ACE API v2",
+        description="Analysis Correlation Engine API v2",
+        version="2.0.0",
+        root_path="/api/v2",
+    )
+
+    # Include routers
+    app.include_router(auth_router, prefix="/auth", tags=["authentication"])
+    app.include_router(health_router, prefix="/health", tags=["health"])
+    app.include_router(observable_types_router, prefix="/observable-types", tags=["observables"])
+
+    return app
+
+
+# Create app instance for imports (used by tests)
+app = create_app()

--- a/aceapi_v2/auth/__init__.py
+++ b/aceapi_v2/auth/__init__.py
@@ -1,0 +1,32 @@
+"""Authentication module for ACE API v2.
+
+Re-exports common auth components for convenient imports:
+    from aceapi_v2.auth import Token, create_access_token, verify_token
+"""
+
+from aceapi_v2.auth.schemas import ApiAuthResult, RefreshRequest, Token, TokenData
+from aceapi_v2.auth.utils import (
+    API_AUTH_TYPE_CONFIG,
+    API_AUTH_TYPE_USER,
+    API_HEADER_NAME,
+    create_access_token,
+    create_refresh_token,
+    verify_api_key,
+    verify_flask_session,
+    verify_token,
+)
+
+__all__ = [
+    "ApiAuthResult",
+    "RefreshRequest",
+    "Token",
+    "TokenData",
+    "API_AUTH_TYPE_CONFIG",
+    "API_AUTH_TYPE_USER",
+    "API_HEADER_NAME",
+    "create_access_token",
+    "create_refresh_token",
+    "verify_api_key",
+    "verify_flask_session",
+    "verify_token",
+]

--- a/aceapi_v2/auth/router.py
+++ b/aceapi_v2/auth/router.py
@@ -1,0 +1,116 @@
+"""Authentication router for ACE API v2."""
+
+from dataclasses import dataclass
+from typing import Annotated, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordRequestForm
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from aceapi_v2.auth.schemas import RefreshRequest, Token
+from aceapi_v2.auth.utils import (
+    create_access_token,
+    create_refresh_token,
+    verify_token,
+)
+from aceapi_v2.database import get_async_session
+from saq.database.model import User
+
+router = APIRouter()
+
+
+@dataclass
+class AuthenticatedUser:
+    id: int
+    username: str
+
+
+async def authenticate_user(
+    username: str, password: str, session: AsyncSession
+) -> Optional[AuthenticatedUser]:
+    """Verify username/password against database.
+
+    Args:
+        username: The username to authenticate
+        password: The password to verify
+        session: Async database session
+
+    Returns:
+        AuthenticatedUser if authentication succeeds, None otherwise
+    """
+    try:
+        result = await session.execute(
+            select(User).where(User.username == username, User.enabled == True)  # noqa: E712
+        )
+        user = result.scalar_one_or_none()
+        if not user:
+            return None
+
+        if user.verify_password(password):
+            # Note: verify_password may update password_hash for legacy hash migration.
+            # The session will commit this change when the request completes.
+            return AuthenticatedUser(id=user.id, username=user.username)
+    except Exception:
+        pass
+    return None
+
+
+@router.post("/token", response_model=Token)
+async def login_for_access_token(
+    form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
+    session: Annotated[AsyncSession, Depends(get_async_session)],
+) -> Token:
+    """Authenticate user and return access + refresh tokens.
+
+    Use OAuth2 password flow: POST with form data containing
+    'username' and 'password' fields.
+    """
+    user = await authenticate_user(form_data.username, form_data.password, session)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect username or password",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return Token(
+        access_token=create_access_token(user.username, user.id),
+        refresh_token=create_refresh_token(user.username, user.id),
+    )
+
+
+@router.post("/refresh", response_model=Token)
+async def refresh_access_token(
+    request: RefreshRequest,
+    session: Annotated[AsyncSession, Depends(get_async_session)],
+) -> Token:
+    """Use refresh token to get new access + refresh tokens.
+
+    TODO: Invalidate the old refresh token once new tokens are issued.
+    """
+    token_data = verify_token(request.refresh_token, expected_type="refresh")
+    if not token_data:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired refresh token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    # Verify user still exists and is enabled
+    result = await session.execute(
+        select(User.id, User.username).where(
+            User.username == token_data.username,
+            User.enabled == True,  # noqa: E712
+        )
+    )
+    row = result.first()
+    if not row:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User not found or disabled",
+        )
+
+    return Token(
+        access_token=create_access_token(row.username, row.id),
+        refresh_token=create_refresh_token(row.username, row.id),
+    )

--- a/aceapi_v2/auth/schemas.py
+++ b/aceapi_v2/auth/schemas.py
@@ -1,0 +1,37 @@
+"""Authentication schemas for ACE API v2."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class Token(BaseModel):
+    """Response model for token endpoints."""
+
+    access_token: str
+    refresh_token: str
+    token_type: str = "bearer"
+
+
+class RefreshRequest(BaseModel):
+    """Request model for token refresh endpoint."""
+
+    refresh_token: str
+
+
+class TokenData(BaseModel):
+    """Decoded token data."""
+
+    username: Optional[str] = None
+    user_id: Optional[int] = None
+    token_type: Optional[str] = None  # "access" or "refresh"
+
+
+@dataclass
+class ApiAuthResult:
+    """Result of API authentication (API key or JWT)."""
+
+    auth_type: Optional[str] = None
+    auth_name: Optional[str] = None
+    auth_user_id: Optional[int] = None

--- a/aceapi_v2/auth/utils.py
+++ b/aceapi_v2/auth/utils.py
@@ -1,0 +1,177 @@
+"""Authentication utilities for ACE API v2."""
+
+import hashlib
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+import jwt
+from itsdangerous import URLSafeTimedSerializer
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from aceapi_v2.auth.schemas import ApiAuthResult, TokenData
+from saq.configuration import get_config
+from saq.database.model import User
+from saq.util import sha256_str
+
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 60
+REFRESH_TOKEN_EXPIRE_DAYS = 7
+
+API_AUTH_TYPE_CONFIG = "config"
+API_AUTH_TYPE_USER = "user"
+API_HEADER_NAME = "x-ace-auth"
+
+
+def _get_secret_key() -> str:
+    """Get JWT signing key from config."""
+    return get_config().api.secret_key
+
+
+def create_access_token(
+    username: str, user_id: int, expires_delta: timedelta | None = None
+) -> str:
+    """Create a JWT access token for the given user."""
+    expire = datetime.now(timezone.utc) + (
+        expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    )
+    to_encode = {
+        "sub": username,
+        "user_id": user_id,
+        "type": "access",
+        "exp": expire,
+    }
+    return jwt.encode(to_encode, _get_secret_key(), algorithm=ALGORITHM)
+
+
+def create_refresh_token(username: str, user_id: int) -> str:
+    """Create a JWT refresh token for the given user."""
+    expire = datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
+    to_encode = {
+        "sub": username,
+        "user_id": user_id,
+        "type": "refresh",
+        "exp": expire,
+    }
+    return jwt.encode(to_encode, _get_secret_key(), algorithm=ALGORITHM)
+
+
+def verify_token(token: str, expected_type: str = "access") -> Optional[TokenData]:
+    """Verify JWT token and return token data if valid.
+
+    Args:
+        token: The JWT token string to verify
+        expected_type: Expected token type ("access" or "refresh")
+
+    Returns:
+        TokenData if valid, None if invalid or expired
+    """
+    try:
+        payload = jwt.decode(
+            token,
+            _get_secret_key(),
+            algorithms=[ALGORITHM],
+            options={"verify_signature": True},
+        )
+        username = payload.get("sub")
+        user_id = payload.get("user_id")
+        token_type = payload.get("type")
+
+        if username is None or token_type != expected_type:
+            return None
+
+        return TokenData(username=username, user_id=user_id, token_type=token_type)
+    except jwt.ExpiredSignatureError:
+        return None
+    except jwt.InvalidTokenError:
+        return None
+
+
+# =============================================================================
+# API Key Authentication
+# =============================================================================
+
+
+def _get_config_api_key_match(auth_sha256: str) -> ApiAuthResult:
+    """Returns an ApiAuthResult if the auth token matches a config API key."""
+    for valid_key_name, valid_key_value in get_config().apikeys.items():
+        if (
+            valid_key_value is not None
+            and auth_sha256.lower() == valid_key_value.strip().lower()
+        ):
+            return ApiAuthResult(
+                auth_type=API_AUTH_TYPE_CONFIG, auth_name=valid_key_name
+            )
+
+    return ApiAuthResult()
+
+
+async def _get_user_api_key_match(
+    auth_sha256: str, session: AsyncSession
+) -> ApiAuthResult:
+    """Returns an ApiAuthResult if the auth token matches a user API key."""
+    result = await session.execute(
+        text("SELECT username, id FROM users WHERE apikey_hash = :apikey"),
+        {"apikey": auth_sha256.lower()},
+    )
+    row = result.first()
+    if not row:
+        return ApiAuthResult()
+
+    return ApiAuthResult(
+        auth_type=API_AUTH_TYPE_USER, auth_name=row[0], auth_user_id=row[1]
+    )
+
+
+async def verify_api_key(auth: str, session: AsyncSession) -> ApiAuthResult:
+    """Verify API key and return auth result if valid."""
+    if not auth:
+        return ApiAuthResult()
+
+    auth_sha256 = sha256_str(auth)
+    return _get_config_api_key_match(auth_sha256) or await _get_user_api_key_match(
+        auth_sha256, session
+    )
+
+
+# =============================================================================
+# Flask Session Cookie Authentication
+# =============================================================================
+
+
+async def verify_flask_session(
+    cookie: str, session: AsyncSession
+) -> Optional[ApiAuthResult]:
+    """Decode Flask session cookie and return auth result.
+
+    Temporary: remove when Flask GUI is retired.
+    """
+    try:
+        s = URLSafeTimedSerializer(
+            get_config().gui.secret_key,
+            salt="cookie-session",
+            signer_kwargs={"key_derivation": "hmac", "digest_method": hashlib.sha512},
+        )
+        data = s.loads(cookie)
+    except Exception:
+        return None
+
+    user_id = data.get("_user_id")
+    if user_id is None:
+        return None
+
+    result = await session.execute(
+        select(User.id, User.username).where(
+            User.id == int(user_id),
+            User.enabled == True,
+        )
+    )
+    row = result.first()
+    if not row:
+        return None
+
+    return ApiAuthResult(
+        auth_type=API_AUTH_TYPE_USER,
+        auth_name=row.username,
+        auth_user_id=row.id,
+    )

--- a/aceapi_v2/database.py
+++ b/aceapi_v2/database.py
@@ -1,0 +1,56 @@
+from collections.abc import AsyncGenerator
+from urllib.parse import quote_plus
+
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from saq.configuration import get_config
+
+
+def build_database_url(db_name: str = "ace") -> str:
+    """Build async SQLAlchemy database URL from config."""
+    db_config = get_config().get_database_config(db_name)
+    # URL-encode password in case it contains special characters
+    password = quote_plus(db_config.password)
+    return f"mysql+aiomysql://{db_config.username}:{password}@{db_config.hostname}:{db_config.port}/{db_config.database}"
+
+
+# Lazy-initialized engine and session maker (config may not be loaded at module import time)
+_engine: AsyncEngine | None = None
+_async_session_maker: async_sessionmaker | None = None
+
+
+def _get_engine() -> AsyncEngine:
+    """Get or create the async engine."""
+    global _engine
+    if _engine is None:
+        _engine = create_async_engine(
+            build_database_url("ace"),
+            echo=False,
+            pool_pre_ping=True,
+        )
+    return _engine
+
+
+def _get_session_maker() -> async_sessionmaker:
+    """Get or create the async session maker."""
+    global _async_session_maker
+    if _async_session_maker is None:
+        _async_session_maker = async_sessionmaker[AsyncSession](
+            _get_engine(), class_=AsyncSession, expire_on_commit=False
+        )
+    return _async_session_maker
+
+
+async def get_async_session() -> AsyncGenerator[AsyncSession]:
+    async with _get_session_maker()() as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise

--- a/aceapi_v2/dependencies.py
+++ b/aceapi_v2/dependencies.py
@@ -1,0 +1,111 @@
+"""FastAPI dependencies for authentication and authorization.
+
+Supports dual authentication:
+- API Key (x-ace-auth header) - for M2M / service authentication
+- JWT Bearer Token (OAuth2 password flow) - for user GUI authentication
+"""
+
+import logging
+from typing import Annotated, Callable, Optional
+
+from fastapi import Depends, HTTPException, Request, Security, status
+from fastapi.security import APIKeyHeader, OAuth2PasswordBearer
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from aceapi_v2.auth import (
+    API_AUTH_TYPE_USER,
+    API_HEADER_NAME,
+    ApiAuthResult,
+    verify_api_key,
+    verify_flask_session,
+    verify_token,
+)
+from aceapi_v2.database import get_async_session
+from saq.permissions.logic import user_has_permission
+
+# Security schemes - both will appear in Swagger UI "Authorize" dialog
+api_key_header = APIKeyHeader(
+    name=API_HEADER_NAME,
+    scheme_name="API Key",
+    description="API key for machine-to-machine authentication",
+    auto_error=False,
+)
+oauth2_scheme = OAuth2PasswordBearer(
+    tokenUrl="/api/v2/auth/token",
+    scheme_name="JWT Token",
+    description="Username/password login for users",
+    auto_error=False,
+)
+
+
+async def get_current_auth(
+    request: Request,
+    session: Annotated[AsyncSession, Depends(get_async_session)],
+    api_key: Annotated[Optional[str], Security(api_key_header)] = None,
+    token: Annotated[Optional[str], Security(oauth2_scheme)] = None,
+) -> ApiAuthResult:
+    """Combined auth dependency - accepts API key, JWT token, or Flask session cookie.
+
+    Tries API key first, then JWT token, then Flask session cookie.
+
+    Returns:
+        ApiAuthResult with authentication details
+
+    Raises:
+        HTTPException: 401 if no authentication method succeeds
+    """
+    # Try API key first (M2M authentication)
+    if api_key:
+        result = await verify_api_key(api_key, session)
+        if result:
+            return result
+
+    # Try JWT token (user authentication)
+    if token:
+        token_data = verify_token(token, expected_type="access")
+        if token_data:
+            return ApiAuthResult(
+                auth_type=API_AUTH_TYPE_USER,
+                auth_name=token_data.username,
+                auth_user_id=token_data.user_id,
+            )
+
+    # Try Flask session cookie
+    # TODO: temporary, remove when Flask GUI is retired)
+    flask_cookie = request.cookies.get("session")
+    if flask_cookie:
+        result = await verify_flask_session(flask_cookie, session)
+        if result:
+            return result
+
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Invalid or missing authentication",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+
+def require_permission(major: str, minor: str) -> Callable:
+    """Factory function that creates a dependency requiring a specific permission.
+
+    Args:
+        major: The major permission category (e.g., "analysis")
+        minor: The minor permission (e.g., "read")
+
+    Returns:
+        A FastAPI dependency function that validates the permission.
+    """
+
+    async def permission_dependency(
+        auth: Annotated[ApiAuthResult, Security(get_current_auth)],
+    ) -> ApiAuthResult:
+        if auth.auth_type == API_AUTH_TYPE_USER:
+            if not user_has_permission(auth.auth_user_id, major, minor):
+                logging.error(
+                    f"user {auth.auth_user_id} does not have permission {major}.{minor}"
+                )
+                raise HTTPException(status_code=403, detail="Permission denied")
+
+        return auth
+
+    return permission_dependency

--- a/aceapi_v2/health/__init__.py
+++ b/aceapi_v2/health/__init__.py
@@ -1,0 +1,1 @@
+"""Health check module for ACE API v2."""

--- a/aceapi_v2/health/router.py
+++ b/aceapi_v2/health/router.py
@@ -1,0 +1,13 @@
+"""Health check router for ACE API v2."""
+
+from fastapi import APIRouter
+
+from aceapi_v2.health.schemas import HealthResponse
+
+router = APIRouter()
+
+
+@router.get("/ping", response_model=HealthResponse)
+async def ping() -> HealthResponse:
+    """Health check endpoint that verifies API is running."""
+    return HealthResponse(result="pong")

--- a/aceapi_v2/health/schemas.py
+++ b/aceapi_v2/health/schemas.py
@@ -1,0 +1,9 @@
+"""Health check schemas for ACE API v2."""
+
+from pydantic import BaseModel
+
+
+class HealthResponse(BaseModel):
+    """Response model for health check endpoint."""
+
+    result: str

--- a/aceapi_v2/observable_types/__init__.py
+++ b/aceapi_v2/observable_types/__init__.py
@@ -1,0 +1,1 @@
+"""Observable types module for ACE API v2."""

--- a/aceapi_v2/observable_types/router.py
+++ b/aceapi_v2/observable_types/router.py
@@ -1,0 +1,32 @@
+"""Observable type router for ACE API v2."""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Security
+from sqlalchemy import distinct, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from aceapi_v2.database import get_async_session
+from aceapi_v2.dependencies import get_current_auth
+from aceapi_v2.observable_types.schemas import ObservableTypeRead
+from aceapi_v2.schemas import ListResponse
+from saq.database.model import Observable
+
+# All routes in this router require authentication
+router = APIRouter(dependencies=[Security(get_current_auth)])
+
+
+@router.get("/", response_model=ListResponse[ObservableTypeRead])
+async def list_observable_types(
+    session: Annotated[AsyncSession, Depends(get_async_session)],
+) -> ListResponse[ObservableTypeRead]:
+    """Return a list of unique observable types from the database.
+
+    Requires authentication (API key or JWT token).
+    """
+    result = await session.execute(
+        select(distinct(Observable.type)).order_by(Observable.type)
+    )
+    return ListResponse(
+        data=[ObservableTypeRead(name=row[0]) for row in result.all()]
+    )

--- a/aceapi_v2/observable_types/schemas.py
+++ b/aceapi_v2/observable_types/schemas.py
@@ -1,0 +1,21 @@
+"""Observable type schemas for ACE API v2."""
+
+from pydantic import BaseModel
+
+
+class ObservableTypeRead(BaseModel):
+    """Response model for reading an observable type."""
+
+    name: str
+
+
+# Future schemas for CRUD operations:
+#
+# class ObservableTypeCreate(BaseModel):
+#     """Request model for creating an observable type."""
+#     name: str
+#     description: str | None = None
+#
+# class ObservableTypeUpdate(BaseModel):
+#     """Request model for updating an observable type."""
+#     description: str | None = None

--- a/aceapi_v2/schemas/__init__.py
+++ b/aceapi_v2/schemas/__init__.py
@@ -1,0 +1,5 @@
+"""Shared schema definitions for ACE API v2."""
+
+from aceapi_v2.schemas.base import ListResponse
+
+__all__ = ["ListResponse"]

--- a/aceapi_v2/schemas/base.py
+++ b/aceapi_v2/schemas/base.py
@@ -1,0 +1,23 @@
+"""Base schema definitions for ACE API v2."""
+
+from typing import Generic, TypeVar
+
+from pydantic import BaseModel
+
+T = TypeVar("T")
+
+
+class ListResponse(BaseModel, Generic[T]):
+    """Generic wrapper for list responses.
+
+    Wrapping list responses in an object allows adding metadata
+    (like pagination) without breaking API compatibility.
+
+    Example response:
+        {"data": [{"name": "ipv4"}, {"name": "domain"}]}
+
+    Future extension:
+        {"data": [...], "total": 150, "page": 1, "per_page": 50}
+    """
+
+    data: list[T]

--- a/api_uvicorn.py
+++ b/api_uvicorn.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+"""FastAPI application entry point for uvicorn.
+
+This module expects the environment to be set up by the container startup
+script (docker/startup/start.sh -> bin/initialize-environment.sh) which sets:
+- SAQ_HOME environment variable
+- SAQ_CONFIG_PATHS environment variable (if load_local_environment exists)
+- Activates the Python virtual environment
+"""
+import os
+
+import aceapi_v2
+from saq.configuration import initialize_configuration
+from saq.constants import ENV_ACE_LOG_CONFIG_PATH
+from saq.logging import initialize_logging
+
+# get SAQ_HOME from environment (set by container startup)
+saq_home = os.environ.get("SAQ_HOME", os.path.dirname(os.path.realpath(__file__)))
+
+# if no logging is specified then use the default console logging configuration
+logging_config_path = os.environ.get(ENV_ACE_LOG_CONFIG_PATH)
+if logging_config_path is None:
+    logging_config_path = os.path.join(saq_home, "etc", "logging_configs", "console_logging.yaml")
+elif not os.path.isabs(logging_config_path):
+    logging_config_path = os.path.join(saq_home, logging_config_path)
+
+# initialize configuration and logging (minimal init for FastAPI)
+initialize_configuration(config_paths=None)
+initialize_logging(logging_config_path)
+
+# create fastapi application
+application = aceapi_v2.create_app()

--- a/app/auth/views.py
+++ b/app/auth/views.py
@@ -78,6 +78,10 @@ def login():
         return render_template('auth/login.html', form=form)
 
     if user is not None and user.verify_password(form.password.data):
+        # TODO: This is temporary and should be removed once every user is migrated to bcrypt
+        # Commit any changes made by verify_password (e.g., password hash migration)
+        get_db().commit()
+
         if not user.enabled:
             flash('User is disabled.')
             return render_template('auth/login.html', form=form)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -277,6 +277,7 @@ services:
     depends_on:
       - http-app
       - http-api
+      - http-api-v2
       - fluent-bit
     volumes:
       - ./etc/nginx/conf.d.external:/etc/nginx/conf.d:ro
@@ -300,6 +301,7 @@ services:
     depends_on:
       - http-app
       - http-api
+      - http-api-v2
       - fluent-bit
     volumes: 
       - ./etc/nginx/conf.d:/etc/nginx/conf.d:ro
@@ -346,7 +348,26 @@ services:
       - "3031"
     cap_add:
       - SYS_PTRACE
-    networks: 
+    networks:
+      - ace
+
+  http-api-v2:
+    environment:
+      <<: *common-env
+      ACE_LOG_CONFIG_PATH: etc/logging_configs/ace_logging.yaml
+      FLUENT_BIT_TAG: ace-api-v2
+    image: ${ACE3_IMAGE_URL:-ace3:latest}
+    depends_on:
+      - ace
+    command: /bin/bash -c "/opt/ace/docker/startup/start.sh uvicorn api_uvicorn:application --host 0.0.0.0 --port 3032 --workers 12 --timeout-keep-alive 300"
+    restart: always
+    volumes: *common-volumes
+    hostname: ace
+    expose:
+      - "3032"
+    cap_add:
+      - SYS_PTRACE
+    networks:
       - ace
 
   redis:

--- a/etc/nginx/conf.d.external/default.conf
+++ b/etc/nginx/conf.d.external/default.conf
@@ -19,6 +19,18 @@ server {
         uwsgi_read_timeout 300s;
     }
 
+    location /api/v2 {
+        proxy_pass http://http-api-v2:3032;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 300s;
+        proxy_connect_timeout 75s;
+        client_max_body_size 0;
+    }
+
     location /api {
         include uwsgi_params;
         uwsgi_pass http-api:3031;

--- a/etc/nginx/conf.d/default.conf
+++ b/etc/nginx/conf.d/default.conf
@@ -11,6 +11,18 @@ server {
         uwsgi_read_timeout 300s;
     }
 
+    location /api/v2 {
+        proxy_pass http://http-api-v2:3032;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 300s;
+        proxy_connect_timeout 75s;
+        client_max_body_size 0;
+    }
+
     location /api {
         include uwsgi_params;
         uwsgi_pass http-api:3031;

--- a/installer/requirements.txt
+++ b/installer/requirements.txt
@@ -87,3 +87,11 @@ numpy
 pandas
 tqdm
 qdrant-client
+
+# FastAPI
+fastapi
+uvicorn[standard]
+python-multipart
+pyjwt
+aiomysql
+bcrypt

--- a/saq/database/model.py
+++ b/saq/database/model.py
@@ -1,8 +1,8 @@
 import base64
 import logging
-from datetime import datetime, date
 import uuid
 import warnings
+from datetime import date, datetime
 from typing import Optional
 
 import bcrypt
@@ -17,7 +17,6 @@ from sqlalchemy import (
     VARBINARY,
     BigInteger,
     Boolean,
-    Column,
     DateTime,
     Enum,
     ForeignKey,
@@ -27,7 +26,14 @@ from sqlalchemy import (
     UniqueConstraint,
     text,
 )
-from sqlalchemy.orm import aliased, reconstructor, relationship, validates
+from sqlalchemy.orm import (
+    Mapped,
+    aliased,
+    mapped_column,
+    reconstructor,
+    relationship,
+    validates,
+)
 from sqlalchemy.orm.session import Session
 from werkzeug.security import check_password_hash as werkzeug_check_password_hash
 
@@ -46,10 +52,6 @@ from saq.constants import (
 )
 from saq.crypto import decrypt_chunk
 from saq.database.meta import Base
-
-from sqlalchemy.orm import reconstructor, relationship, validates, aliased, mapped_column, Mapped
-from sqlalchemy.orm.session import Session
-
 from saq.database.pool import get_db, get_db_connection
 from saq.database.retry import execute_with_retry, retry
 from saq.database.util.sync import sync_observable

--- a/tests/aceapi/test_analysis.py
+++ b/tests/aceapi/test_analysis.py
@@ -38,7 +38,7 @@ def test_api_analysis_submit(test_client):
             'extensions': { KEY_PLAYBOOK_URL: "http://playbook" },
         }, cls=_JSONEncoder),
         'file': (io.BytesIO(b'Hello, world!'), 'sample.dat'),
-    }, content_type='multipart/form-data', headers = { 'x-ice-auth': get_config().api.api_key })
+    }, content_type='multipart/form-data', headers = { 'x-ace-auth': get_config().api.api_key })
 
     result = result.get_json()
     assert result
@@ -51,7 +51,7 @@ def test_api_analysis_submit(test_client):
     uuid = result['uuid']
     #_id = result['id']
 
-    result = test_client.get(url_for('analysis.get_analysis', uuid=uuid), headers = { 'x-ice-auth': get_config().api.api_key })
+    result = test_client.get(url_for('analysis.get_analysis', uuid=uuid), headers = { 'x-ace-auth': get_config().api.api_key })
     result = result.get_json()
     assert result
     assert 'result' in result
@@ -105,22 +105,22 @@ def test_api_analysis_submit(test_client):
     assert row[2] == get_global_runtime_settings().saq_node_id
     assert row[3] == 'analysis'
 
-    result = test_client.get(url_for('analysis.get_details', uuid=uuid, name=result['file_path']), headers = { 'x-ice-auth': get_config().api.api_key })
+    result = test_client.get(url_for('analysis.get_details', uuid=uuid, name=result['file_path']), headers = { 'x-ace-auth': get_config().api.api_key })
     result = result.get_json()
     assert result
     result = result['result']
     assert 'hello' in result
     assert result['hello'] == 'world'
 
-    result = test_client.get(url_for('analysis.get_file', uuid=uuid, file_uuid_or_name=file_uuid), headers = { 'x-ice-auth': get_config().api.api_key })
+    result = test_client.get(url_for('analysis.get_file', uuid=uuid, file_uuid_or_name=file_uuid), headers = { 'x-ace-auth': get_config().api.api_key })
     assert result.status_code == 200
     assert result.data == b'Hello, world!'
 
-    result = test_client.get(url_for('analysis.get_file', uuid=uuid, file_uuid_or_name='sample.dat'), headers = { 'x-ice-auth': get_config().api.api_key })
+    result = test_client.get(url_for('analysis.get_file', uuid=uuid, file_uuid_or_name='sample.dat'), headers = { 'x-ace-auth': get_config().api.api_key })
     assert result.status_code == 200
     assert result.data == b'Hello, world!'
 
-    result = test_client.get(url_for('analysis.get_status', uuid=uuid), headers = { 'x-ice-auth': get_config().api.api_key })
+    result = test_client.get(url_for('analysis.get_status', uuid=uuid), headers = { 'x-ace-auth': get_config().api.api_key })
     assert result.status_code == 200
     result = result.get_json()
     assert result
@@ -136,7 +136,7 @@ def test_api_analysis_submit(test_client):
     assert result['workload']['analysis_mode'] == 'analysis'
     assert isinstance(parse_event_time(result['workload']['insert_date']), datetime)
 
-    result = test_client.get(url_for('analysis.get_submission', uuid=uuid), headers = { 'x-ice-auth': get_config().api.api_key })
+    result = test_client.get(url_for('analysis.get_submission', uuid=uuid), headers = { 'x-ace-auth': get_config().api.api_key })
     assert result.status_code, 200
     result = result.get_json()
     assert result
@@ -193,7 +193,7 @@ def test_api_analysis_submit_queue(test_client):
             'tags': [ 'alert_tag_1', 'alert_tag_2' ],
         }, cls=_JSONEncoder),
         'file': (io.BytesIO(b'Hello, world!'), 'sample.dat'),
-    }, content_type='multipart/form-data', headers = { 'x-ice-auth': get_config().api.api_key })
+    }, content_type='multipart/form-data', headers = { 'x-ace-auth': get_config().api.api_key })
 
     result = result.get_json()
     assert result
@@ -201,7 +201,7 @@ def test_api_analysis_submit_queue(test_client):
     result = result['result']
     assert result['uuid']
     uuid = result['uuid']
-    result = test_client.get(url_for('analysis.get_analysis', uuid=uuid), headers = { 'x-ice-auth': get_config().api.api_key })
+    result = test_client.get(url_for('analysis.get_analysis', uuid=uuid), headers = { 'x-ace-auth': get_config().api.api_key })
     result = result.get_json()
     assert result
     assert 'result' in result
@@ -253,22 +253,22 @@ def test_api_analysis_submit_queue(test_client):
     assert row[2] == get_global_runtime_settings().saq_node_id
     assert row[3] == 'analysis'
 
-    result = test_client.get(url_for('analysis.get_details', uuid=uuid, name=result['file_path']), headers = { 'x-ice-auth': get_config().api.api_key })
+    result = test_client.get(url_for('analysis.get_details', uuid=uuid, name=result['file_path']), headers = { 'x-ace-auth': get_config().api.api_key })
     result = result.get_json()
     assert result
     result = result['result']
     assert 'hello' in result
     assert result['hello'] == 'world'
 
-    result = test_client.get(url_for('analysis.get_file', uuid=uuid, file_uuid_or_name=file_uuid), headers = { 'x-ice-auth': get_config().api.api_key })
+    result = test_client.get(url_for('analysis.get_file', uuid=uuid, file_uuid_or_name=file_uuid), headers = { 'x-ace-auth': get_config().api.api_key })
     assert result.status_code == 200
     assert result.data == b'Hello, world!'
 
-    result = test_client.get(url_for('analysis.get_file', uuid=uuid, file_uuid_or_name='sample.dat'), headers = { 'x-ice-auth': get_config().api.api_key })
+    result = test_client.get(url_for('analysis.get_file', uuid=uuid, file_uuid_or_name='sample.dat'), headers = { 'x-ace-auth': get_config().api.api_key })
     assert result.status_code == 200
     assert result.data == b'Hello, world!'
 
-    result = test_client.get(url_for('analysis.get_status', uuid=uuid), headers = { 'x-ice-auth': get_config().api.api_key })
+    result = test_client.get(url_for('analysis.get_status', uuid=uuid), headers = { 'x-ace-auth': get_config().api.api_key })
     assert result.status_code == 200
     result = result.get_json()
     assert result
@@ -284,7 +284,7 @@ def test_api_analysis_submit_queue(test_client):
     assert result['workload']['analysis_mode'] == 'analysis'
     assert isinstance(parse_event_time(result['workload']['insert_date']), datetime)
 
-    result = test_client.get(url_for('analysis.get_submission', uuid=uuid), headers = { 'x-ice-auth': get_config().api.api_key })
+    result = test_client.get(url_for('analysis.get_submission', uuid=uuid), headers = { 'x-ace-auth': get_config().api.api_key })
     assert result.status_code == 200
     result = result.get_json()
     assert result
@@ -320,7 +320,7 @@ def test_api_analysis_submit_queue(test_client):
 
 @pytest.mark.integration
 def test_api_analysis_submit_invalid(test_client):
-    result = test_client.post(url_for('analysis.submit'), data={}, content_type='multipart/form-data', headers = { 'x-ice-auth': get_config().api.api_key })
+    result = test_client.post(url_for('analysis.submit'), data={}, content_type='multipart/form-data', headers = { 'x-ace-auth': get_config().api.api_key })
     assert result.status_code == 400
     assert result.data.decode() == 'missing analysis field (see documentation)'
 
@@ -342,7 +342,7 @@ def test_api_analysis_submit_invalid(test_client):
             'tags': [ 'alert_tag_1', 'alert_tag_2' ],
         }, cls=_JSONEncoder),
         'file': (io.BytesIO(b'Hello, world!'), 'sample.dat'),
-    }, content_type='multipart/form-data', headers = { 'x-ice-auth': get_config().api.api_key })
+    }, content_type='multipart/form-data', headers = { 'x-ace-auth': get_config().api.api_key })
 
     assert result.status_code == 400
     assert result.data.decode() == 'wrong company invalid_company_name (are you sending to the correct system?)'
@@ -363,7 +363,7 @@ def test_api_analysis_submit_invalid(test_client):
             'tags': [ 'alert_tag_1', 'alert_tag_2' ],
         }, cls=_JSONEncoder),
         'file': (io.BytesIO(b'Hello, world!'), 'sample.dat'),
-    }, content_type='multipart/form-data', headers = { 'x-ice-auth': get_config().api.api_key })
+    }, content_type='multipart/form-data', headers = { 'x-ace-auth': get_config().api.api_key })
 
     assert result.status_code == 400
     assert result.data.decode() == 'missing description field in submission'
@@ -384,7 +384,7 @@ def test_api_analysis_submit_invalid(test_client):
             'tags': [ 'alert_tag_1', 'alert_tag_2' ],
         }, cls=_JSONEncoder),
         'file': (io.BytesIO(b'Hello, world!'), 'sample.dat'),
-    }, content_type='multipart/form-data', headers = { 'x-ice-auth': get_config().api.api_key })
+    }, content_type='multipart/form-data', headers = { 'x-ace-auth': get_config().api.api_key })
 
     assert result.status_code == 400
     assert 'invalid event time format' in result.data.decode()
@@ -421,7 +421,7 @@ def test_api_analysis_submit_invalid(test_client):
                 'tags': [ 'alert_tag_1', 'alert_tag_2' ],
             }, cls=_JSONEncoder),
             'file': (io.BytesIO(b'Hello, world!'), 'sample.dat'),
-        }, content_type='multipart/form-data', headers = { 'x-ice-auth': get_config().api.api_key })
+        }, content_type='multipart/form-data', headers = { 'x-ace-auth': get_config().api.api_key })
 
     #assert result.status_code == 400
     #assert result.data.decode() == 'an observable is missing the value field'
@@ -447,7 +447,7 @@ def test_api_analysis_submit_invalid(test_client):
                 'tags': [ 'alert_tag_1', 'alert_tag_2' ],
             }, cls=_JSONEncoder),
             'file': (io.BytesIO(b'Hello, world!'), 'sample.dat'),
-        }, content_type='multipart/form-data', headers = { 'x-ice-auth': get_config().api.api_key })
+        }, content_type='multipart/form-data', headers = { 'x-ace-auth': get_config().api.api_key })
 
     #assert result.status_code == 400
     #assert result.data.decode(), 'an observable is missing the type field'
@@ -472,7 +472,7 @@ def test_api_analysis_submit_invalid(test_client):
                 'tags': [ 'alert_tag_1', 'alert_tag_2' ],
             }, cls=_JSONEncoder),
             'file': (io.BytesIO(b'Hello, world!'), 'sample.dat'),
-        }, content_type='multipart/form-data', headers = { 'x-ice-auth': get_config().api.api_key })
+        }, content_type='multipart/form-data', headers = { 'x-ace-auth': get_config().api.api_key })
 
     #assert result.status_code == 400
     #assert 'an observable has an invalid time format' in result.data.decode()
@@ -482,11 +482,11 @@ def test_api_analysis_submit_invalid(test_client):
 
 @pytest.mark.integration
 def test_api_analysis_invalid_status(test_client):
-    result = test_client.get(url_for('analysis.get_status', uuid='invalid'), headers = { 'x-ice-auth': get_config().api.api_key })
+    result = test_client.get(url_for('analysis.get_status', uuid='invalid'), headers = { 'x-ace-auth': get_config().api.api_key })
     assert result.status_code == 400
 
     test_uuid = str(uuid.uuid4())
-    result = test_client.get(url_for('analysis.get_status', uuid=test_uuid), headers = { 'x-ice-auth': get_config().api.api_key })
+    result = test_client.get(url_for('analysis.get_status', uuid=test_uuid), headers = { 'x-ace-auth': get_config().api.api_key })
     assert result.status_code == 400
     assert result.data.decode() == 'invalid uuid {}'.format(test_uuid)
 
@@ -530,7 +530,7 @@ rule test_filter {
             'tags': [ 'alert_tag_1', 'alert_tag_2' ],
         }, cls=_JSONEncoder),
         'file': (io.BytesIO(b'Hello, world!'), 'sample.dat'),
-    }, content_type='multipart/form-data', headers = { 'x-ice-auth': get_config().api.api_key })
+    }, content_type='multipart/form-data', headers = { 'x-ace-auth': get_config().api.api_key })
 
     result = result.get_json()
     assert result
@@ -539,7 +539,7 @@ rule test_filter {
     assert result['uuid']
     assert 'tuning_matches' in result
 
-    result = test_client.get(url_for('analysis.get_analysis', uuid=result['uuid']), headers = { 'x-ice-auth': get_config().api.api_key })
+    result = test_client.get(url_for('analysis.get_analysis', uuid=result['uuid']), headers = { 'x-ace-auth': get_config().api.api_key })
     assert result.status_code == 400
 
     # remove the tuning rule
@@ -562,7 +562,7 @@ rule test_filter {
             'tags': [ 'alert_tag_1', 'alert_tag_2' ],
         }, cls=_JSONEncoder),
         'file': (io.BytesIO(b'Hello, world!'), 'sample.dat'),
-    }, content_type='multipart/form-data', headers = { 'x-ice-auth': get_config().api.api_key })
+    }, content_type='multipart/form-data', headers = { 'x-ace-auth': get_config().api.api_key })
 
     result = result.get_json()
     assert result
@@ -571,7 +571,7 @@ rule test_filter {
     assert result['uuid']
     assert 'tuning_matches' not in result
 
-    result = test_client.get(url_for('analysis.get_analysis', uuid=result['uuid']), headers = { 'x-ice-auth': get_config().api.api_key })
+    result = test_client.get(url_for('analysis.get_analysis', uuid=result['uuid']), headers = { 'x-ace-auth': get_config().api.api_key })
     assert result.status_code == 200
 
     # test tuning by file
@@ -604,7 +604,7 @@ rule test_files {
             'tags': [ 'alert_tag_1', 'alert_tag_2' ],
         }, cls=_JSONEncoder),
         'file': (io.BytesIO(b'Hello, world!'), 'sample.dat'),
-    }, content_type='multipart/form-data', headers = { 'x-ice-auth': get_config().api.api_key })
+    }, content_type='multipart/form-data', headers = { 'x-ace-auth': get_config().api.api_key })
 
     result = result.get_json()
     assert result
@@ -613,5 +613,5 @@ rule test_files {
     assert result['uuid']
     assert 'tuning_matches' in result
 
-    result = test_client.get(url_for('analysis.get_analysis', uuid=result['uuid']), headers = { 'x-ice-auth': get_config().api.api_key })
+    result = test_client.get(url_for('analysis.get_analysis', uuid=result['uuid']), headers = { 'x-ace-auth': get_config().api.api_key })
     assert result.status_code == 400

--- a/tests/aceapi/test_email.py
+++ b/tests/aceapi/test_email.py
@@ -38,7 +38,7 @@ def test_get_archived_email_success(test_client, archived_email):
     result = test_client.get(
         url_for('email.get_archived_email'),
         query_string={'message_id': TEST_MESSAGE_ID},
-        headers={'x-ice-auth': get_config().api.api_key},
+        headers={'x-ace-auth': get_config().api.api_key},
     )
 
     assert result.status_code == 200
@@ -52,7 +52,7 @@ def test_get_archived_email_missing_message_id(test_client):
     """test that missing message_id parameter returns 400"""
     result = test_client.get(
         url_for('email.get_archived_email'),
-        headers={'x-ice-auth': get_config().api.api_key},
+        headers={'x-ace-auth': get_config().api.api_key},
     )
 
     assert result.status_code == 400
@@ -64,7 +64,7 @@ def test_get_archived_email_unknown_message_id(test_client):
     result = test_client.get(
         url_for('email.get_archived_email'),
         query_string={'message_id': '<unknown-message-id@example.com>'},
-        headers={'x-ice-auth': get_config().api.api_key},
+        headers={'x-ace-auth': get_config().api.api_key},
     )
 
     assert result.status_code == 404
@@ -81,7 +81,7 @@ def test_get_archived_email_missing_encryption_key(test_client, archived_email):
         result = test_client.get(
             url_for('email.get_archived_email'),
             query_string={'message_id': TEST_MESSAGE_ID},
-            headers={'x-ice-auth': get_config().api.api_key},
+            headers={'x-ace-auth': get_config().api.api_key},
         )
 
         assert result.status_code == 500
@@ -123,7 +123,7 @@ def test_get_archived_email_remote_server(test_client, tmpdir, patch_email_archi
     result = test_client.get(
         url_for('email.get_archived_email'),
         query_string={'message_id': TEST_REMOTE_MESSAGE_ID},
-        headers={'x-ice-auth': get_config().api.api_key},
+        headers={'x-ace-auth': get_config().api.api_key},
         follow_redirects=False
     )
 

--- a/tests/aceapi/test_engine.py
+++ b/tests/aceapi/test_engine.py
@@ -30,7 +30,7 @@ def test_download(test_client):
     root.save()
 
     # ask for a download
-    result = test_client.get(url_for('engine.download', uuid=root.uuid), headers = { 'x-ice-auth': get_config().api.api_key })
+    result = test_client.get(url_for('engine.download', uuid=root.uuid), headers = { 'x-ace-auth': get_config().api.api_key })
 
     # we should get back a tar file
     tar_path = os.path.join(get_temp_dir(), 'download.tar')
@@ -92,7 +92,7 @@ def test_upload(test_client):
                                         'overwrite': False,
                                         'sync': True,
                                     }),
-                                    'archive': (fp, os.path.basename(tar_path))}, headers = { 'x-ice-auth': get_config().api.api_key })
+                                    'archive': (fp, os.path.basename(tar_path))}, headers = { 'x-ace-auth': get_config().api.api_key })
 
     # make sure it uploaded
     root = RootAnalysis(storage_dir=get_storage_dir(root.uuid))
@@ -137,7 +137,7 @@ def test_upload_move(test_client):
                                         'sync': False,
                                         'move': True,
                                     }),
-                                    'archive': (fp, os.path.basename(tar_path))}, headers = { 'x-ice-auth': get_config().api.api_key })
+                                    'archive': (fp, os.path.basename(tar_path))}, headers = { 'x-ace-auth': get_config().api.api_key })
 
     # make sure it moved
     get_db().close() # clear the stale session
@@ -169,7 +169,7 @@ def test_clear(test_client):
     assert acquire_lock(root.uuid, lock_uuid)
 
     # clear it
-    result = test_client.get(url_for('engine.clear', uuid=root.uuid, lock_uuid=lock_uuid), headers = { 'x-ice-auth': get_config().api.api_key })
+    result = test_client.get(url_for('engine.clear', uuid=root.uuid, lock_uuid=lock_uuid), headers = { 'x-ace-auth': get_config().api.api_key })
     assert result.status_code == 200
 
     # make sure the directory is gone
@@ -194,7 +194,7 @@ def test_clear_invalid_lock(test_client):
     assert acquire_lock(root.uuid, lock_uuid)
 
     # clear it but with the wrong lock uuid
-    result = test_client.get(url_for('engine.clear', uuid=root.uuid, lock_uuid=str(uuid.uuid4())), headers = { 'x-ice-auth': get_config().api.api_key })
+    result = test_client.get(url_for('engine.clear', uuid=root.uuid, lock_uuid=str(uuid.uuid4())), headers = { 'x-ace-auth': get_config().api.api_key })
     assert result.status_code == 400
 
     # directory is still there
@@ -219,7 +219,7 @@ def test_clear_unknown_uuid(test_client):
     assert acquire_lock(root.uuid, lock_uuid)
 
     # clear it with the wrong uuid
-    result = test_client.get(url_for('engine.clear', uuid=str(uuid.uuid4()), lock_uuid=lock_uuid), headers = { 'x-ice-auth': get_config().api.api_key })
+    result = test_client.get(url_for('engine.clear', uuid=str(uuid.uuid4()), lock_uuid=lock_uuid), headers = { 'x-ace-auth': get_config().api.api_key })
     assert result.status_code == 400
 
     # directory is still there

--- a/tests/aceapi/test_hunt.py
+++ b/tests/aceapi/test_hunt.py
@@ -27,7 +27,7 @@ HUNT_VALIDATE_URL = "/hunt/validate"
 @pytest.fixture
 def auth_headers():
     """Returns authentication headers for API requests."""
-    return {"x-ice-auth": get_config().api.api_key}
+    return {"x-ace-auth": get_config().api.api_key}
 
 
 # =============================================================================

--- a/tests/aceapi/test_intel.py
+++ b/tests/aceapi/test_intel.py
@@ -66,7 +66,7 @@ def test_set_observable(test_client):
         })
     }
 
-    client_kwargs = { "headers": { 'x-ice-auth': get_config().api.api_key } }
+    client_kwargs = { "headers": { 'x-ace-auth': get_config().api.api_key } }
     result = test_client.post(url_for('intel.set_observables'), data=data, **client_kwargs)
 
     get_db().close()
@@ -83,7 +83,7 @@ def test_set_observable(test_client):
         })
     }
 
-    client_kwargs = { "headers": { 'x-ice-auth': get_config().api.api_key } }
+    client_kwargs = { "headers": { 'x-ace-auth': get_config().api.api_key } }
     result = test_client.post(url_for('intel.set_observables'), data=data, **client_kwargs)
 
     get_db().close()
@@ -100,7 +100,7 @@ def test_set_observable(test_client):
         })
     }
 
-    client_kwargs = { "headers": { 'x-ice-auth': get_config().api.api_key } }
+    client_kwargs = { "headers": { 'x-ace-auth': get_config().api.api_key } }
     result = test_client.post(url_for('intel.set_observables'), data=data, **client_kwargs)
 
     get_db().close()
@@ -123,7 +123,7 @@ def test_set_observable(test_client):
         })
     }
 
-    client_kwargs = { "headers": { 'x-ice-auth': get_config().api.api_key } }
+    client_kwargs = { "headers": { 'x-ace-auth': get_config().api.api_key } }
     result = test_client.post(url_for('intel.set_observables'), data=data, **client_kwargs)
 
     get_db().close()
@@ -148,7 +148,7 @@ def test_set_observable(test_client):
         })
     }
 
-    client_kwargs = { "headers": { 'x-ice-auth': get_config().api.api_key } }
+    client_kwargs = { "headers": { 'x-ace-auth': get_config().api.api_key } }
     result = test_client.post(url_for('intel.set_observables'), data=data, **client_kwargs)
 
     get_db().close()
@@ -178,7 +178,7 @@ def test_set_observable(test_client):
         })
     }
 
-    client_kwargs = { "headers": { 'x-ice-auth': get_config().api.api_key } }
+    client_kwargs = { "headers": { 'x-ace-auth': get_config().api.api_key } }
     result = test_client.post(url_for('intel.set_observables'), data=data, **client_kwargs)
 
     get_db().close()
@@ -190,7 +190,7 @@ def test_set_observable(test_client):
 def test_set_observable_as_user(test_client):
     user = get_db().query(User).first()
     api_key = set_user_api_key(user.id)
-    client_kwargs = { "headers": { 'x-ice-auth': set_user_api_key(user.id) } }
+    client_kwargs = { "headers": { 'x-ace-auth': set_user_api_key(user.id) } }
 
     root = create_root_analysis()
     root.add_observable_by_spec(F_FQDN, "test.com")
@@ -247,7 +247,7 @@ def test_set_observable_as_user(test_client):
 
 @pytest.mark.integration
 def test_get_observable(test_client):
-    client_kwargs = { "headers": { 'x-ice-auth': get_config().api.api_key } }
+    client_kwargs = { "headers": { 'x-ace-auth': get_config().api.api_key } }
 
     result = test_client.get(url_for('intel.get_observables'), **client_kwargs)
     assert result.status_code == 200

--- a/tests/aceapi_v2/auth/test_auth.py
+++ b/tests/aceapi_v2/auth/test_auth.py
@@ -1,0 +1,174 @@
+"""Tests for aceapi_v2 authentication router."""
+
+import pytest
+from sqlalchemy import select
+from werkzeug.security import generate_password_hash
+
+from saq.database.model import User, hash_password
+
+pytestmark = pytest.mark.integration
+
+
+# TODO: These tests are temporary and should be deleted once all users
+# are migrated to bcrypt password hashes.
+class TestPasswordHashMigration:
+    """Test automatic password hash migration from werkzeug to bcrypt.
+
+    Migration happens in User.verify_password() - any code path that verifies
+    a password will automatically migrate legacy werkzeug hashes to bcrypt.
+    """
+
+    @pytest.mark.asyncio
+    async def test_verify_password_migrates_werkzeug_hash(self, session):
+        """Test that User.verify_password migrates werkzeug hashes to bcrypt."""
+        username = "model_migrate_user"
+        password = "testpassword123"
+
+        # Create user with werkzeug hash
+        werkzeug_hash = generate_password_hash(password)
+        user = User(
+            username=username,
+            email=f"{username}@localhost",
+            password_hash=werkzeug_hash,
+            display_name="Model Migration Test User",
+            queue="default",
+            timezone="UTC",
+            enabled=True,
+        )
+        session.add(user)
+        await session.commit()
+
+        # Verify it's a werkzeug hash
+        assert not user.password_hash.startswith("$2"), "Expected werkzeug hash"
+
+        # Call verify_password - this should migrate the hash
+        assert user.verify_password(password) is True
+
+        # Verify the hash was updated in-memory to bcrypt
+        assert user.password_hash.startswith(
+            "$2b$"
+        ), f"Expected bcrypt hash, got: {user.password_hash[:20]}..."
+
+        # Commit and verify it persists
+        await session.commit()
+        session.expire_all()
+
+        result = await session.execute(select(User).where(User.username == username))
+        refreshed_user = result.scalar_one()
+        assert refreshed_user.password_hash.startswith("$2b$")
+
+        # Verify password still works with new hash
+        assert refreshed_user.verify_password(password) is True
+
+    @pytest.mark.asyncio
+    async def test_verify_password_does_not_change_bcrypt_hash(self, session):
+        """Test that User.verify_password doesn't modify bcrypt hashes."""
+        username = "model_bcrypt_user"
+        password = "testpassword456"
+
+        # Create user with bcrypt hash
+        bcrypt_hash = hash_password(password)
+        user = User(
+            username=username,
+            email=f"{username}@localhost",
+            password_hash=bcrypt_hash,
+            display_name="Model Bcrypt Test User",
+            queue="default",
+            timezone="UTC",
+            enabled=True,
+        )
+        session.add(user)
+        await session.commit()
+        original_hash = user.password_hash
+
+        # Call verify_password
+        assert user.verify_password(password) is True
+
+        # Hash should be unchanged
+        assert user.password_hash == original_hash
+
+    @pytest.mark.asyncio
+    async def test_api_login_migrates_werkzeug_hash(self, session, unauth_client):
+        """Test that API login migrates werkzeug password hashes to bcrypt."""
+        username = "api_migrate_user"
+        password = "testpassword123"
+
+        # Create user with werkzeug hash
+        werkzeug_hash = generate_password_hash(password)
+        user = User(
+            username=username,
+            email=f"{username}@localhost",
+            password_hash=werkzeug_hash,
+            display_name="API Migration Test User",
+            queue="default",
+            timezone="UTC",
+            enabled=True,
+        )
+        session.add(user)
+        await session.commit()
+        user_id = user.id
+
+        # Verify it's a werkzeug hash
+        assert not user.password_hash.startswith("$2"), "Expected werkzeug hash"
+
+        # Login via the API
+        response = await unauth_client.post(
+            "/auth/token",
+            data={"username": username, "password": password},
+        )
+        assert response.status_code == 200
+        assert "access_token" in response.json()
+
+        # Verify the hash has been migrated to bcrypt
+        session.expire_all()
+        result = await session.execute(
+            select(User.password_hash).where(User.id == user_id)
+        )
+        row = result.first()
+        assert row.password_hash.startswith(
+            "$2b$"
+        ), f"Expected bcrypt hash, got: {row.password_hash[:20]}..."
+
+        # Verify login still works with the new hash
+        response = await unauth_client.post(
+            "/auth/token",
+            data={"username": username, "password": password},
+        )
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_api_login_does_not_change_bcrypt_hash(self, session, unauth_client):
+        """Test that API login doesn't modify bcrypt password hashes."""
+        username = "api_bcrypt_user"
+        password = "testpassword456"
+
+        # Create user with bcrypt hash
+        bcrypt_hash = hash_password(password)
+        user = User(
+            username=username,
+            email=f"{username}@localhost",
+            password_hash=bcrypt_hash,
+            display_name="API Bcrypt Test User",
+            queue="default",
+            timezone="UTC",
+            enabled=True,
+        )
+        session.add(user)
+        await session.commit()
+        user_id = user.id
+        original_hash = user.password_hash
+
+        # Login via the API
+        response = await unauth_client.post(
+            "/auth/token",
+            data={"username": username, "password": password},
+        )
+        assert response.status_code == 200
+
+        # Verify the hash has NOT changed
+        session.expire_all()
+        result = await session.execute(
+            select(User.password_hash).where(User.id == user_id)
+        )
+        row = result.first()
+        assert row.password_hash == original_hash, "Bcrypt hash should not be modified"

--- a/tests/aceapi_v2/auth/test_flask_session_auth.py
+++ b/tests/aceapi_v2/auth/test_flask_session_auth.py
@@ -1,0 +1,72 @@
+"""
+Tests for Flask session cookie authentication in FastAPI.
+
+TODO: Remove this entire file when we no longer use Flask.
+"""
+
+import hashlib
+
+import pytest
+from httpx import AsyncClient
+from itsdangerous import URLSafeTimedSerializer
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from saq.configuration import get_config
+from saq.database.model import User
+
+pytestmark = pytest.mark.integration
+
+
+def _make_flask_session_cookie(user_id) -> str:
+    """Create a Flask session cookie encoding the given user_id."""
+    s = URLSafeTimedSerializer(
+        get_config().gui.secret_key,
+        salt="cookie-session",
+        signer_kwargs={"key_derivation": "hmac", "digest_method": hashlib.sha512},
+    )
+    return s.dumps({"_user_id": str(user_id)})
+
+
+class TestFlaskSessionAuth:
+    """Test Flask session cookie as a third auth fallback."""
+
+    @pytest.mark.asyncio
+    async def test_valid_flask_session_cookie(
+        self, unauth_client: AsyncClient, test_user: User
+    ):
+        """Valid Flask session cookie should authenticate successfully."""
+        cookie = _make_flask_session_cookie(test_user.id)
+        unauth_client.cookies.set("session", cookie)
+        response = await unauth_client.get("/observable-types/")
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_invalid_flask_session_cookie(self, unauth_client: AsyncClient):
+        """Tampered/invalid cookie should return 401."""
+        unauth_client.cookies.set("session", "not-a-valid-cookie")
+        response = await unauth_client.get("/observable-types/")
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_flask_session_cookie_nonexistent_user(
+        self, unauth_client: AsyncClient
+    ):
+        """Cookie for a user ID that doesn't exist should return 401."""
+        cookie = _make_flask_session_cookie(999999)
+        unauth_client.cookies.set("session", cookie)
+        response = await unauth_client.get("/observable-types/")
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_flask_session_cookie_disabled_user(
+        self, session: AsyncSession, unauth_client: AsyncClient, test_user: User
+    ):
+        """Cookie for a disabled user should return 401."""
+        test_user.enabled = False
+        session.add(test_user)
+        await session.commit()
+
+        cookie = _make_flask_session_cookie(test_user.id)
+        unauth_client.cookies.set("session", cookie)
+        response = await unauth_client.get("/observable-types/")
+        assert response.status_code == 401

--- a/tests/aceapi_v2/conftest.py
+++ b/tests/aceapi_v2/conftest.py
@@ -1,0 +1,141 @@
+from collections.abc import AsyncGenerator
+from datetime import timedelta
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import (
+    AsyncConnection,
+    AsyncEngine,
+    AsyncSession,
+    create_async_engine,
+)
+
+from aceapi_v2.application import app
+from aceapi_v2.auth import create_access_token
+from aceapi_v2.database import build_database_url, get_async_session
+from saq.database.model import User
+
+
+@pytest.fixture(autouse=True)
+def global_function_setup():
+    """Override global fixture - savepoint rollback handles cleanup for these tests."""
+    yield
+
+
+@pytest_asyncio.fixture
+async def engine() -> AsyncGenerator[AsyncEngine]:
+    """Function-scoped engine."""
+    engine = create_async_engine(build_database_url(), echo=False)
+    yield engine
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def connection(engine: AsyncEngine) -> AsyncGenerator[AsyncConnection]:
+    """Connection with outer transaction that rolls back after test.
+
+    This provides automatic cleanup - all changes made during the test
+    are rolled back when the test completes.
+    """
+    async with engine.connect() as conn:
+        trans = await conn.begin()
+        try:
+            yield conn
+        finally:
+            await trans.rollback()
+
+
+@pytest_asyncio.fixture
+async def session(connection: AsyncConnection) -> AsyncGenerator[AsyncSession]:
+    """Session bound to the shared connection using savepoints.
+
+    - join_transaction_mode="create_savepoint": commit() only commits a savepoint,
+      not the outer transaction
+    - expire_on_commit=False: prevents lazy-load greenlet errors when accessing
+      attributes after commit
+    - Shares transaction view with API sessions (both bound to same connection)
+    """
+    session = AsyncSession(
+        bind=connection,
+        join_transaction_mode="create_savepoint",
+        expire_on_commit=False,
+    )
+    try:
+        yield session
+    finally:
+        await session.close()
+
+
+@pytest_asyncio.fixture
+async def _override_db_session(connection: AsyncConnection):
+    """Override get_async_session to use the test transaction."""
+
+    async def override_get_session():
+        session = AsyncSession(
+            bind=connection,
+            join_transaction_mode="create_savepoint",
+            expire_on_commit=False,
+        )
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+        finally:
+            await session.close()
+
+    app.dependency_overrides[get_async_session] = override_get_session
+    yield
+    app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def unauth_client(_override_db_session) -> AsyncGenerator[AsyncClient]:
+    """HTTP client without authentication credentials."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def client(
+    _override_db_session, valid_access_token: str
+) -> AsyncGenerator[AsyncClient]:
+    """HTTP client with a valid Bearer token pre-set."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        headers={"Authorization": f"Bearer {valid_access_token}"},
+    ) as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def test_user(session: AsyncSession) -> User:
+    """Get the unittest user for testing."""
+    result = await session.execute(select(User).where(User.username == "unittest"))
+    user = result.scalar_one_or_none()
+    if user is None:
+        raise ValueError("unittest user not found in database")
+    return user
+
+
+@pytest_asyncio.fixture
+async def expired_access_token(test_user: User) -> str:
+    """Expired access token for the test user."""
+    return create_access_token(
+        test_user.username,
+        test_user.id,
+        expires_delta=-timedelta(minutes=1),
+    )
+
+
+@pytest_asyncio.fixture
+async def valid_access_token(test_user: User) -> str:
+    """Valid access token for the test user."""
+    return create_access_token(test_user.username, test_user.id)

--- a/tests/aceapi_v2/observable_types/test_router.py
+++ b/tests/aceapi_v2/observable_types/test_router.py
@@ -1,0 +1,112 @@
+"""Tests for aceapi_v2 observable types router."""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from saq.database.model import Observable
+
+pytestmark = pytest.mark.integration
+
+
+class TestObservableTypes:
+    """Test the observable types endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_list_observable_types_requires_auth(
+        self, unauth_client: AsyncClient
+    ):
+        """Test that the endpoint requires authentication."""
+        response = await unauth_client.get("/observable-types/")
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_list_observable_types_empty(self, client: AsyncClient):
+        """Test listing observable types returns proper structure."""
+        response = await client.get("/observable-types/")
+        assert response.status_code == 200
+        data = response.json()
+        # Should have the wrapped response format
+        assert "data" in data
+        assert isinstance(data["data"], list)
+
+    @pytest.mark.asyncio
+    async def test_list_observable_types_returns_unique_types(
+        self, session: AsyncSession, client: AsyncClient
+    ):
+        """Test that endpoint returns unique observable types."""
+        # Create test observables with different types
+        observables = [
+            Observable(type="ipv4", sha256=b"a" * 32, value=b"192.168.1.1"),
+            Observable(type="ipv4", sha256=b"b" * 32, value=b"192.168.1.2"),
+            Observable(type="domain", sha256=b"c" * 32, value=b"example.com"),
+            Observable(type="url", sha256=b"d" * 32, value=b"https://example.com"),
+            Observable(type="domain", sha256=b"e" * 32, value=b"test.com"),
+        ]
+        for obs in observables:
+            session.add(obs)
+        await session.commit()
+
+        response = await client.get("/observable-types/")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert "data" in data
+        types = data["data"]
+        assert isinstance(types, list)
+
+        # Extract type names from response objects
+        type_names = [t["name"] for t in types]
+
+        # Should contain our types (uniquely)
+        assert "ipv4" in type_names
+        assert "domain" in type_names
+        assert "url" in type_names
+
+        # Should be sorted alphabetically
+        assert type_names == sorted(type_names)
+
+    @pytest.mark.asyncio
+    async def test_list_observable_types_sorted(
+        self, session: AsyncSession, client: AsyncClient
+    ):
+        """Test that observable types are returned in sorted order."""
+        # Create observables with types that would be unsorted if not ordered
+        observables = [
+            Observable(type="zebra_type", sha256=b"z" * 32, value=b"z"),
+            Observable(type="alpha_type", sha256=b"a" * 32, value=b"a"),
+            Observable(type="middle_type", sha256=b"m" * 32, value=b"m"),
+        ]
+        for obs in observables:
+            session.add(obs)
+        await session.commit()
+
+        response = await client.get("/observable-types/")
+        assert response.status_code == 200
+
+        data = response.json()
+        type_names = [t["name"] for t in data["data"]]
+        assert type_names == sorted(type_names)
+
+    @pytest.mark.asyncio
+    async def test_list_observable_types_response_format(
+        self, session: AsyncSession, client: AsyncClient
+    ):
+        """Test that response follows the expected schema."""
+        # Create a test observable
+        observable = Observable(type="test_type", sha256=b"t" * 32, value=b"test")
+        session.add(observable)
+        await session.commit()
+
+        response = await client.get("/observable-types/")
+        assert response.status_code == 200
+
+        data = response.json()
+        # Verify response structure
+        assert "data" in data
+        assert isinstance(data["data"], list)
+
+        # Find our test type and verify its structure
+        test_types = [t for t in data["data"] if t["name"] == "test_type"]
+        assert len(test_types) == 1
+        assert test_types[0] == {"name": "test_type"}

--- a/tests/app/auth/test_edit.py
+++ b/tests/app/auth/test_edit.py
@@ -261,8 +261,8 @@ class TestEditUsers:
             assert target_user.enabled == False
             
             # Verify password was changed
-            from werkzeug.security import check_password_hash
-            assert check_password_hash(target_user.password_hash, "NewPass456!")
+            from saq.database.model import verify_password_hash
+            assert verify_password_hash("NewPass456!", target_user.password_hash)
             
             # Verify permissions were updated
             permission = db.query(AuthUserPermission).filter(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -442,7 +442,7 @@ def mock_api_call(test_client, monkeypatch):
         if timeout is not None:
             kwargs['timeout'] = timeout
         if api_key is not None:
-            kwargs['headers'] = { "x-ice-auth": api_key }
+            kwargs['headers'] = { "x-ace-auth": api_key }
 
         response = func(command, **kwargs)
 

--- a/tests/saq/modules/test_email.py
+++ b/tests/saq/modules/test_email.py
@@ -129,7 +129,7 @@ def test_mailbox_submission(test_client, root_analysis, datadir):
                 'tags': [ ],
             }, cls=_JSONEncoder),
             'file': (fp, 'rfc822.email'),
-            }, content_type='multipart/form-data', headers = { 'x-ice-auth': get_config().api.api_key })
+            }, content_type='multipart/form-data', headers = { 'x-ace-auth': get_config().api.api_key })
 
     result = result.get_json()
     assert result

--- a/tests/saq/modules/test_http.py
+++ b/tests/saq/modules/test_http.py
@@ -104,7 +104,7 @@ def test_bro_http_submission(test_client, datadir):
                     (reply_fp, 'CZZiJd1zicZKNMMrV1.0.reply'),
                     (reply_entity_fp, 'CZZiJd1zicZKNMMrV1.0.reply.entity'),
                     (request_fp, 'CZZiJd1zicZKNMMrV1.0.request'), ],
-        }, content_type='multipart/form-data', headers = { 'x-ice-auth': get_config().api.api_key })
+        }, content_type='multipart/form-data', headers = { 'x-ace-auth': get_config().api.api_key })
 
     ready_fp.close()
     reply_fp.close()


### PR DESCRIPTION
This PR adds an initial FastAPI implementation that will sit next to the Flask API until we're able to fully migrate. FastAPI is set up to authenticate requests with:
- JWT
- API keys (for machine-to-machine auth)
- Flask session cookie (so the existing GUI "just works")

In addition, this PR adds some logic for when users log in to check to see if their hashed password needs to be re-hashed using `bcrypt`. The passwords were originally hashed with `werkzeug`, which is bundled with Flask, so this will let us remove `werkzeug` later down the road when we're fully migrated to FastAPI.